### PR TITLE
Release v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.16.0] – 2026-07-26
 ### Changed
 - **Flat HA-theme redesign — hybrid tokens, decorative glow removed.** Purely visual/theming, no behavior change (one small bugfix called out below). Closes #56
   - Added a `GLP-TOKENS v1` block (`--glp-radius`, `--glp-radius-sm`, `--glp-bg`, `--glp-surface`, `--glp-border`, `--glp-text`, `--glp-sub`, `--glp-accent`, `--glp-ok`, `--glp-warn`, `--glp-err`, plus the 4 chart series tokens) that reads Home Assistant's own theme CSS variables first (`--ha-card-background`, `--primary-text-color`, `--divider-color`, `--primary-color`, `--error-color`, etc.) and only falls back to the old standalone Apple-iOS palette values when a theme doesn't set them. This exact block is the shared contract with `glp-order-card` (new test `test/token-sync.test.js`, skips cleanly when the neighbor repo/block isn't present locally). No new YAML config option — no `theme:` switch, HA's active theme always wins.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   Custom Lovelace card for <a href="https://github.com/mxkissnr/gaggiuino-local-profiler">Gaggiuino Local Profiler</a>.<br/>
-  Premium dark card with hero metric typography, glowing shot chart and warm layered palette — feels like Decent Espresso or Apple Health, built for espresso.<br/>
+  Premium card with hero metric typography, a clean shot chart and warm layered palette — feels like Decent Espresso or Apple Health, built for espresso. Follows your Home Assistant theme, light or dark.<br/>
   Mobile-first with swipe gestures, dot navigation, custom profile picker and live brewing view — all from the <a href="https://github.com/mxkissnr/glp-integration">GLP HA Integration</a>.
 </p>
 
@@ -27,6 +27,7 @@
 
 <p align="center">
   <img src="docs/screenshots/card.png" alt="GLP Shot Card showing a preheated Gaggiuino, the current profile, live machine tiles, the last shot's metrics and its pressure/flow/temperature/weight curve" width="420"/>
+  <img src="docs/screenshots/card-light.png" alt="The same GLP Shot Card rendered against a light Home Assistant theme" width="420"/>
 </p>
 
 ---

--- a/glp-card.js
+++ b/glp-card.js
@@ -1,4 +1,4 @@
-const GLP_CARD_VERSION = '2.15.0';
+const GLP_CARD_VERSION = '2.16.0';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
 // DE wording is the original card text; language follows hass.language (DE/EN/IT/FR/ES/NL, falls back to EN).


### PR DESCRIPTION
## Summary
- Bump `GLP_CARD_VERSION` to 2.16.0
- Finalize CHANGELOG entry for the flat HA-theme redesign (#57): hybrid theme tokens with GLP-palette fallback, automatic WCAG-contrast-safe semantic colors, unified colorblind-safe chart palette, decorative glow removed, radii unified with glp-order-card
- README: tagline updated to reflect theme-following behavior (no longer dark-only), added light-theme screenshot

No config options changed — existing YAML configs work unchanged.

## Test plan
- [x] `npm test` — 20/20 passing
- [x] `npm run build` — syntax check passing