### PR TITLE
Centralize render guards, add pending-render catch-up

### DIFF
--- a/glp-card.js
+++ b/glp-card.js
@@ -1026,6 +1026,10 @@ class GlpCard extends HTMLElement {
     this._readyByInteracting = false;
     this._profileOpen  = false;
     this._animating     = false;
+    // set when a render was requested while _renderBlocked() (#72) — replayed
+    // once by _requestRender() as soon as the blocking interaction ends,
+    // instead of being discarded like it was before.
+    this._pendingRender = false;
     this._shotIndex     = 0;
     this._prevShotIndex = -1;
     this._recentShots   = [];
@@ -1135,7 +1139,10 @@ class GlpCard extends HTMLElement {
     const input = this.shadowRoot.getElementById('glp-readyby-input');
     if (!input) return;
     input.addEventListener('focus', () => { this._readyByInteracting = true; });
-    input.addEventListener('blur', () => { this._readyByInteracting = false; });
+    input.addEventListener('blur', () => {
+      this._readyByInteracting = false;
+      if (this._pendingRender) this._requestRender();
+    });
   }
 
   _bindTabBtns() {
@@ -1288,7 +1295,7 @@ class GlpCard extends HTMLElement {
     if (!force && sig === this._ordersSig) return;
     this._ordersSig = sig;
     this._orders = active;
-    if (!this._profileInteracting && !this._animating && !this._maintConfirm && !this._readyByInteracting) this._render();
+    this._requestRender();
   }
 
   async _orderAction(id, action, body) {
@@ -1412,7 +1419,11 @@ class GlpCard extends HTMLElement {
 
     const newSwipe   = this.shadowRoot.querySelector('.swipe-target');
     const newContent = this.shadowRoot.querySelector('.swipe-content');
-    if (!oldClone || !newSwipe || !newContent) { this._animating = false; return; }
+    if (!oldClone || !newSwipe || !newContent) {
+      this._animating = false;
+      if (this._pendingRender) this._requestRender();
+      return;
+    }
 
     // prev = going to older shot → new content enters from right, old exits left
     const enterX = dir === 'prev' ? '36px' : '-36px';
@@ -1438,6 +1449,7 @@ class GlpCard extends HTMLElement {
         if (oldClone.parentNode) oldClone.remove();
         ['transform', 'transition', 'opacity'].forEach(p => newContent.style.removeProperty(p));
         this._animating = false;
+        if (this._pendingRender) this._requestRender();
       }, 250);
     }));
   }
@@ -1456,7 +1468,7 @@ class GlpCard extends HTMLElement {
     { const l = String(hass?.language || hass?.locale?.language || 'de').slice(0, 2).toLowerCase(); LANG = SUPPORTED_LANGS.includes(l) ? l : 'en'; }
     if (!this._ordersPoll) this._startOrdersPoll();
     this._loadBeansInfo();
-    if (!this._profileInteracting && !this._animating && !this._maintConfirm && !this._readyByInteracting) this._render();
+    this._requestRender();
   }
 
   // ── Bean metadata (via the integration REST proxy, app >= 1.96) ───────────
@@ -1662,8 +1674,27 @@ class GlpCard extends HTMLElement {
     }
   }
 
+  // Single source of truth for "a full re-render would currently wipe out an
+  // in-progress user interaction" (#72 — this used to be duplicated verbatim
+  // at the orders-poll and `set hass` call sites, and any new interactive
+  // flag had to be added to both by hand or a render would silently blow
+  // away focus/open state, exactly as happened in #64/#66/#68).
+  _renderBlocked() {
+    return !!(this._profileInteracting || this._animating || this._maintConfirm || this._readyByInteracting);
+  }
+
+  // Renders now if nothing is blocking, otherwise defers via `_pendingRender`
+  // (ported from glp-order-card.js's `_pendingRender` pattern) so the
+  // deferred render is replayed once by whichever call flips the blocking
+  // flag back off, instead of being discarded outright.
+  _requestRender() {
+    if (this._renderBlocked()) { this._pendingRender = true; return; }
+    this._render();
+  }
+
   _render() {
     if (!this._hass || !this._config) return;
+    this._pendingRender = false;
 
     const prefix    = this._resolvePrefix();
     const bsPrefix  = prefix.replace(/^sensor\./, 'binary_sensor.');

--- a/test/render-guard.test.js
+++ b/test/render-guard.test.js
@@ -1,0 +1,166 @@
+// Render-guard centralization + pending-render catch-up (#72). Same
+// vm-context approach as the other suites: loads the real glp-card.js into a
+// sandboxed vm context and exercises GlpCard.prototype methods directly,
+// without a real shadow DOM/customElements.
+//
+// `_render()` itself (full shadow-DOM rebuild) is out of scope here, same
+// boundary as the rest of this suite (see ready-by.test.js) — it is spied on
+// instead of exercised for real; visual correctness is verified separately
+// via `npm run screenshot`. The spy also clears `_pendingRender`, mirroring
+// the real `_render()`'s own contract (glp-card.js: it resets
+// `this._pendingRender = false` as soon as an actual render happens) so the
+// "replayed exactly once" assertions below are meaningful.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadGlpCard() {
+  let src = fs.readFileSync(path.join(__dirname, '..', 'glp-card.js'), 'utf8');
+  src = src.replace(
+    "customElements.define('glp-card', GlpCard);",
+    "customElements.define('glp-card', GlpCard); globalThis.__GlpCard = GlpCard;"
+  );
+
+  class HTMLElement {}
+  const context = { HTMLElement, customElements: { define() {} }, window: {}, console, URL, setTimeout, clearTimeout };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(src, context, { filename: 'glp-card.js' });
+  return context.__GlpCard;
+}
+
+const GlpCard = loadGlpCard();
+
+function makeInstance() {
+  const inst = Object.create(GlpCard.prototype);
+  inst._profileInteracting = false;
+  inst._animating = false;
+  inst._maintConfirm = null;
+  inst._readyByInteracting = false;
+  inst._pendingRender = false;
+  return inst;
+}
+
+// Replaces `_render` with a counting spy that also clears `_pendingRender`,
+// mirroring the real method's contract (see file header).
+function spyOnRender(inst) {
+  let count = 0;
+  inst._render = () => { count++; inst._pendingRender = false; };
+  return () => count;
+}
+
+// ── _renderBlocked() ────────────────────────────────────────────────────────
+
+test('_renderBlocked() is false when no guard flag is set', () => {
+  const inst = makeInstance();
+  assert.equal(inst._renderBlocked(), false);
+});
+
+test('_renderBlocked() is true for each guard flag independently', () => {
+  const flags = ['_profileInteracting', '_animating', '_readyByInteracting'];
+  for (const flag of flags) {
+    const inst = makeInstance();
+    inst[flag] = true;
+    assert.equal(inst._renderBlocked(), true, `expected blocked when ${flag} is true`);
+  }
+  const inst = makeInstance();
+  inst._maintConfirm = 'descale';
+  assert.equal(inst._renderBlocked(), true, 'expected blocked when _maintConfirm is set');
+});
+
+// ── _requestRender() ────────────────────────────────────────────────────────
+
+test('_requestRender() renders immediately when nothing blocks (unchanged behavior)', () => {
+  const inst = makeInstance();
+  const renderCount = spyOnRender(inst);
+  inst._requestRender();
+  assert.equal(renderCount(), 1);
+  assert.equal(inst._pendingRender, false);
+});
+
+test('_requestRender() defers via _pendingRender instead of rendering when blocked', () => {
+  const inst = makeInstance();
+  inst._profileInteracting = true;
+  const renderCount = spyOnRender(inst);
+  inst._requestRender();
+  assert.equal(renderCount(), 0);
+  assert.equal(inst._pendingRender, true);
+});
+
+// ── catch-up on guard release ───────────────────────────────────────────────
+
+test('a blocked render is replayed exactly once once the blocking interaction ends (ready-by blur)', () => {
+  const inst = makeInstance();
+  const renderCount = spyOnRender(inst);
+
+  const listeners = {};
+  const fakeInput = { addEventListener(type, handler) { listeners[type] = handler; } };
+  inst.shadowRoot = { getElementById: id => (id === 'glp-readyby-input' ? fakeInput : null) };
+  inst._bindReadyByPicker();
+
+  listeners.focus();
+  assert.equal(inst._readyByInteracting, true);
+
+  // A render request arrives mid-interaction — must be deferred, not dropped.
+  inst._requestRender();
+  assert.equal(renderCount(), 0);
+  assert.equal(inst._pendingRender, true);
+
+  // Interaction ends — the deferred render is replayed exactly once.
+  listeners.blur();
+  assert.equal(inst._readyByInteracting, false);
+  assert.equal(renderCount(), 1);
+  assert.equal(inst._pendingRender, false);
+
+  // A second, unrelated blur (no pending render outstanding) must not
+  // trigger another render.
+  listeners.focus();
+  listeners.blur();
+  assert.equal(renderCount(), 1);
+});
+
+test('blur with nothing pending does not force a render (no-op catch-up)', () => {
+  const inst = makeInstance();
+  const renderCount = spyOnRender(inst);
+
+  const listeners = {};
+  const fakeInput = { addEventListener(type, handler) { listeners[type] = handler; } };
+  inst.shadowRoot = { getElementById: id => (id === 'glp-readyby-input' ? fakeInput : null) };
+  inst._bindReadyByPicker();
+
+  listeners.focus();
+  listeners.blur();
+  assert.equal(renderCount(), 0);
+});
+
+test('a render requested while blocked by one flag is still deferred if another flag remains set on release', () => {
+  const inst = makeInstance();
+  inst._profileInteracting = true;
+  const renderCount = spyOnRender(inst);
+
+  const listeners = {};
+  const fakeInput = { addEventListener(type, handler) { listeners[type] = handler; } };
+  inst.shadowRoot = { getElementById: id => (id === 'glp-readyby-input' ? fakeInput : null) };
+  inst._bindReadyByPicker();
+
+  listeners.focus(); // _readyByInteracting = true too, now two flags block
+  inst._requestRender();
+  assert.equal(renderCount(), 0);
+  assert.equal(inst._pendingRender, true);
+
+  // Only the ready-by interaction ends — _profileInteracting is still true,
+  // so the render must stay deferred rather than firing early.
+  listeners.blur();
+  assert.equal(renderCount(), 0);
+  assert.equal(inst._pendingRender, true);
+
+  // Now the remaining flag clears too, and a fresh _requestRender() (as the
+  // real call sites would issue on their own next trigger) flushes it.
+  inst._profileInteracting = false;
+  inst._requestRender();
+  assert.equal(renderCount(), 1);
+});


### PR DESCRIPTION
## Summary
- `_renderBlocked()` — single home for the guard condition that previously existed verbatim at the orders-poll and `set hass` call sites (`glp-card.js:1291`/`1459` pre-change). Any future interactive flag now needs to be added in exactly one place.
- `_requestRender()` — renders immediately when nothing blocks, otherwise sets `_pendingRender = true` and defers. Ported from `glp-order-card.js`'s existing `_pendingRender` pattern (`:650-653`, `:958-960`, `:989`). A blocked render is now replayed once the blocking interaction ends, instead of being discarded outright.
- Catch-up added at every site where a guard flag flips back to `false`: ready-by picker blur, and both exit paths of the swipe animation (`_navShotAnimated`). The profile-picker-close and maint-confirm-close sites already had an unconditional `_render()` immediately after clearing their flag, which now self-satisfies any pending request since `_render()` resets `_pendingRender` as soon as an actual render happens — no separate catch-up needed there.
- (c) from the issue (merging `_pendingProfile`/`_pendingReadyByTargetAt` into one `_optimistic` object with a shared expiry) was **intentionally left out**: their confirm-clear comparisons differ in kind (strict equality for profile vs. a truthiness check for ready-by, the latter already flagged as fragile by #70's Set/Cancel duality), and unifying the expiry mechanism risked touching that same fragile area for a purely cosmetic gain. (a) and (b) are the structural fix and deliver the value on their own.

Closes #72

## Test plan
- [x] `npm test` — 45/45 green (38 pre-existing + 7 new in `test/render-guard.test.js`), none of the pre-existing 38 were modified.
- [x] `npm run lint` — 0 errors (2 pre-existing `innerHTML` warnings, unrelated to this change).
- [x] `npm run screenshot` before/after (dark + light) — pixel-diffed with ImageMagick `compare -metric AE`: only the live uptime-ticker second differs (`2:00:00` vs `2:00:01`, a real clock tick between the two captures), everything else byte-identical. Visually confirmed by reading both PNGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)