### PR TITLE
Fix ready-by pending-override, id-first bean matching, extend shared-block sync test

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: mxkissnr/glp-order-card
-          path: ../neighbor-glp-order-card
+          path: neighbor-glp-order-card
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: npm run test:coverage
         env:
-          GLP_ORDER_CARD_PATH: ${{ github.workspace }}/../neighbor-glp-order-card/glp-order-card.js
+          GLP_ORDER_CARD_PATH: ${{ github.workspace }}/neighbor-glp-order-card/glp-order-card.js
 
       - name: Build check (syntax)
         run: npm run build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Checkout neighbor repo (glp-order-card) for shared-block sync test (#74)
+        uses: actions/checkout@v7
+        with:
+          repository: mxkissnr/glp-order-card
+          path: ../neighbor-glp-order-card
+
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
@@ -42,6 +48,8 @@ jobs:
 
       - name: Run tests
         run: npm run test:coverage
+        env:
+          GLP_ORDER_CARD_PATH: ${{ github.workspace }}/../neighbor-glp-order-card/glp-order-card.js
 
       - name: Build check (syntax)
         run: npm run build

--- a/glp-card.js
+++ b/glp-card.js
@@ -1043,6 +1043,7 @@ class GlpCard extends HTMLElement {
     this._ordersSig = null;
     this._ordersPoll = null;
     this._beansInfo = null;
+    this._beansInfoById = null;
     this._beansInfoAt = 0;
     this._beansInfoUnavailable = false;
     this._orderEtaFor = null;
@@ -1486,13 +1487,21 @@ class GlpCard extends HTMLElement {
       const r = await this._hass.fetchWithAuth('/api/glp/library/beans-info');
       if (!r.ok) { this._beansInfoUnavailable = true; return; }
       const list = await r.json();
-      this._beansInfo = new Map((Array.isArray(list) ? list : [])
-        .map(b => [String(b.name || '').toLowerCase(), b]));
+      const beans = Array.isArray(list) ? list : [];
+      this._beansInfoById = new Map(beans.filter(b => b.id != null).map(b => [b.id, b]));
+      this._beansInfo = new Map(beans.map(b => [String(b.name || '').toLowerCase(), b]));
     } catch { /* transient — retry after the cache window */ }
   }
 
-  _beanExtraHtml(coffee) {
-    const bean = this._beansInfo?.get(String(coffee || '').toLowerCase());
+  // #55 (follow-up to gaggiuino-local-profiler#456): prefers the stable
+  // beanId link over the free-text coffee name — mirrors the app's
+  // resolveBeanForAnnotation, since a delete+reimport under the same name
+  // gets a new id but keeps stale references matching by name alone. Falls
+  // back to name matching when beanId isn't available (shots that predate
+  // beanId on the annotation, or an integration too old to expose it).
+  _beanExtraHtml(coffee, beanId) {
+    const bean = (beanId != null && this._beansInfoById?.get(beanId))
+      || this._beansInfo?.get(String(coffee || '').toLowerCase());
     if (!bean) return '';
     const parts = [];
     const fl = flagEmoji(bean.origin);
@@ -2030,7 +2039,7 @@ class GlpCard extends HTMLElement {
               <div class="shot-profile">${esc(profile)}</div>
               <div class="shot-meta">
                 ${drinkType ? `<span class="shot-drink">${esc(drinkType)}</span>` : ''}
-                ${coffee    ? `<span class="shot-coffee">☕ ${esc(coffee)}</span>${this._beanExtraHtml(coffee)}` : ''}
+                ${coffee    ? `<span class="shot-coffee">☕ ${esc(coffee)}</span>${this._beanExtraHtml(coffee, shotObj?.beanId)}` : ''}
               </div>
               ${(grinder || grind) ? `<div class="shot-grind">⚙️ ${esc([grinder, grind].filter(Boolean).join(' · '))}</div>` : ''}
             </div>

--- a/glp-card.js
+++ b/glp-card.js
@@ -215,17 +215,23 @@ function roastAgeDays(str) {
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 function esc(s) {
+  // GLP-SHARED:esc v1 — body kept byte-identical with glp-order-card.js's _esc()
   if (s == null) return '';
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  // /GLP-SHARED:esc v1
 }
 
 function safeUrl(url) {
+  // GLP-SHARED:safeUrl v1 — body kept byte-identical with glp-order-card.js's
+  // _safeUrl() (#74 — that copy had drifted to returning the raw input,
+  // losing this reasoning; re-sync it from here)
   if (!url) return null;
   // Returns u.href (the normalized/re-serialized URL), not the raw input —
   // the raw string could still contain quote/angle-bracket characters that
   // break out of an href="..." attribute even though the protocol is fine.
   try { const u = new URL(url); return (u.protocol==='http:'||u.protocol==='https:') ? u.href : null; }
   catch { return null; }
+  // /GLP-SHARED:safeUrl v1
 }
 
 function parseTs(val) {
@@ -1525,16 +1531,22 @@ class GlpCard extends HTMLElement {
   _resolvePrefix() {
     if (this._config.entity_prefix) return this._config.entity_prefix;
     const candidates = Object.keys(this._hass.states).filter(id => id.endsWith('_machine_status'));
-    if (this._config.machine) {
+    if (this._config?.machine) {
+      // GLP-SHARED:machine-match v1 — needle/needleSlug + find() predicate
+      // kept byte-identical with glp-order-card.js's
+      // _findMachineStatusEntity(); what each side does with `matched`
+      // afterward differs (a prefix here vs the raw entity id there), so
+      // only the predicate itself is shared.
       const needle = String(this._config.machine).toLowerCase();
       const needleSlug = needle.replace(/\s+/g, '_');
       const matched = candidates.find(id =>
-        this._hass.states[id].attributes.friendly_name?.toLowerCase().includes(needle) ||
+        this._hass.states[id]?.attributes?.friendly_name?.toLowerCase().includes(needle) ||
         id.toLowerCase().includes(needleSlug));
+      // /GLP-SHARED:machine-match v1
       if (matched) return matched.replace(/machine_status$/, '');
     }
     const found = candidates.find(id =>
-      this._hass.states[id].attributes.friendly_name?.toLowerCase().includes('gaggiuino'));
+      this._hass.states[id]?.attributes?.friendly_name?.toLowerCase().includes('gaggiuino'));
     if (found) return found.replace(/machine_status$/, '');
     const fallback = candidates[0];
     return fallback ? fallback.replace(/machine_status$/, '') : 'sensor.gaggiuino_local_profiler_';
@@ -1633,6 +1645,8 @@ class GlpCard extends HTMLElement {
     </div>`;
   }
 
+  /* GLP-SHARED:contrast v1 — kept byte-identical with glp-order-card.js's
+     _luminanceOf()/_applySemanticColorContrast() */
   // Resolves the relative luminance of a CSS color string by normalizing it
   // through a scratch element's computed style (handles hex/rgb/named/etc —
   // whatever the real cascade actually resolved a custom property to).
@@ -1687,6 +1701,7 @@ class GlpCard extends HTMLElement {
       this.style.setProperty('--glp-accent-text', accentLuminance > 0.179 ? '#000' : '#fff');
     }
   }
+  /* /GLP-SHARED:contrast v1 */
 
   // Single source of truth for "a full re-render would currently wipe out an
   // in-progress user interaction" (#72 — this used to be duplicated verbatim

--- a/glp-card.js
+++ b/glp-card.js
@@ -1223,8 +1223,13 @@ class GlpCard extends HTMLElement {
       if (!realTargetAt) { clearTimeout(this._pendingReadyByTimer); this._pendingReadyByTargetAt = null; }
       else return { targetAt: null, plannedAt: null };
     } else if (this._pendingReadyByTargetAt) {
-      if (realTargetAt) { clearTimeout(this._pendingReadyByTimer); this._pendingReadyByTargetAt = null; }
-      else return { targetAt: this._pendingReadyByTargetAt, plannedAt: null };
+      // Compare by value, not truthiness (#70): a stale realTargetAt (old
+      // target still live, or the #68 unavailable-fallback cache holding the
+      // pre-reschedule value) must not clear a pending re-schedule to a
+      // *different* new target — only the matching value counts as confirmed.
+      if (realTargetAt && realTargetAt.getTime() === this._pendingReadyByTargetAt.getTime()) {
+        clearTimeout(this._pendingReadyByTimer); this._pendingReadyByTargetAt = null;
+      } else return { targetAt: this._pendingReadyByTargetAt, plannedAt: null };
     }
     return { targetAt: realTargetAt, plannedAt: realPlannedAt };
   }

--- a/test/bean-enrichment.test.js
+++ b/test/bean-enrichment.test.js
@@ -1,0 +1,79 @@
+// Shot-card bean enrichment (#55, follow-up to gaggiuino-local-profiler#456):
+// _beanExtraHtml() must prefer the stable beanId over the free-text coffee
+// name, falling back to name matching only when beanId isn't available.
+// Same vm-context approach as ready-by.test.js/machine-config.test.js: loads
+// the real glp-card.js into a sandboxed vm context and exercises
+// GlpCard.prototype methods directly.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadGlpCard() {
+  let src = fs.readFileSync(path.join(__dirname, '..', 'glp-card.js'), 'utf8');
+  src = src.replace(
+    "customElements.define('glp-card', GlpCard);",
+    "customElements.define('glp-card', GlpCard); globalThis.__GlpCard = GlpCard;"
+  );
+
+  class HTMLElement {}
+  const context = { HTMLElement, customElements: { define() {} }, window: {}, console, URL, setTimeout, clearTimeout };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(src, context, { filename: path.join(__dirname, '..', 'glp-card.js') });
+  return context.__GlpCard;
+}
+
+const GlpCard = loadGlpCard();
+
+function makeInstance({ beansInfoById = [], beansInfo = [] } = {}) {
+  const inst = Object.create(GlpCard.prototype);
+  inst._config = {};
+  inst._hass = { states: {} };
+  inst._beansInfoById = new Map(beansInfoById);
+  inst._beansInfo = new Map(beansInfo);
+  return inst;
+}
+
+test('_beanExtraHtml() matches by beanId even when the coffee name has drifted from the library', () => {
+  // Simulates a delete+reimport: the shot annotation's name string is now
+  // stale ("Old Name"), but the id still resolves to the current bean.
+  const bean = { name: 'Old Name', origin: 'ET', variety: 'Heirloom', roastDate: null };
+  const inst = makeInstance({ beansInfoById: [[42, bean]], beansInfo: [] });
+  const html = inst._beanExtraHtml('Old Name', 42);
+  assert.match(html, /Heirloom/);
+});
+
+test('_beanExtraHtml() prefers the beanId match over a name match that points at a different bean', () => {
+  const byId   = { name: 'Renamed Bean', origin: 'KE', variety: 'SL28', roastDate: null };
+  const byName = { name: 'Some Coffee', origin: 'BR', variety: 'Bourbon', roastDate: null };
+  const inst = makeInstance({
+    beansInfoById: [[7, byId]],
+    beansInfo: [['some coffee', byName]],
+  });
+  const html = inst._beanExtraHtml('Some Coffee', 7);
+  assert.match(html, /SL28/);
+  assert.doesNotMatch(html, /Bourbon/);
+});
+
+test('_beanExtraHtml() falls back to name matching when beanId is absent (shots that predate it)', () => {
+  const bean = { name: 'Legacy Coffee', origin: 'CO', variety: 'Castillo', roastDate: null };
+  const inst = makeInstance({ beansInfoById: [], beansInfo: [['legacy coffee', bean]] });
+  const html = inst._beanExtraHtml('Legacy Coffee', undefined);
+  assert.match(html, /Castillo/);
+});
+
+test('_beanExtraHtml() falls back to name matching when the beanId does not resolve (deleted bean)', () => {
+  const bean = { name: 'Still Here', origin: 'PE', variety: 'Typica', roastDate: null };
+  const inst = makeInstance({ beansInfoById: [], beansInfo: [['still here', bean]] });
+  const html = inst._beanExtraHtml('Still Here', 999); // 999 not in the library
+  assert.match(html, /Typica/);
+});
+
+test('_beanExtraHtml() returns empty string when neither beanId nor name resolves', () => {
+  const inst = makeInstance();
+  assert.equal(inst._beanExtraHtml('Unknown Coffee', 123), '');
+});

--- a/test/ready-by.test.js
+++ b/test/ready-by.test.js
@@ -226,11 +226,47 @@ test('_readReadyBy() clears the pending Set override once the sensor reports a r
       'sensor.gaggiuino_local_profiler_preheat_planned_switch_on_at': { state: '2026-07-28T06:40:00.000Z' },
     },
   });
-  inst._pendingReadyByTargetAt = new Date(2026, 6, 28, 7, 0, 0);
+  // pending value constructed from the ISO string (not local y/m/d/h/m/s
+  // fields) so the getTime() match against the sensor's UTC state is
+  // timezone-independent.
+  inst._pendingReadyByTargetAt = new Date('2026-07-28T07:00:00.000Z');
   const { targetAt, plannedAt } = inst._readReadyBy();
   assert.equal(targetAt.toISOString(), '2026-07-28T07:00:00.000Z');
   assert.equal(plannedAt.toISOString(), '2026-07-28T06:40:00.000Z');
   // resolved — pending override cleared so future renders read the sensor
+  assert.equal(inst._pendingReadyByTargetAt, null);
+});
+
+test('_readReadyBy() (#70) keeps a pending re-schedule when the sensor still reports the old target', () => {
+  const inst = makeInstance({
+    states: {
+      'sensor.gaggiuino_local_profiler_machine_status': { attributes: {} },
+      // sensor still holds the *old* target — hasn't caught up to the new pick yet
+      'sensor.gaggiuino_local_profiler_preheat_ready_by_target_at': { state: '2026-07-28T07:00:00.000Z' },
+      'sensor.gaggiuino_local_profiler_preheat_planned_switch_on_at': { state: '2026-07-28T06:40:00.000Z' },
+    },
+  });
+  const newPending = new Date('2026-07-28T08:00:00.000Z'); // 08:00, different from the sensor's 07:00
+  inst._pendingReadyByTargetAt = newPending;
+  const { targetAt, plannedAt } = inst._readReadyBy();
+  assert.equal(targetAt, newPending);
+  assert.equal(plannedAt, null);
+  // not confirmed yet — a truthy-but-mismatched realTargetAt must not clear it
+  assert.equal(inst._pendingReadyByTargetAt, newPending);
+});
+
+test('_readReadyBy() (#70) clears a pending re-schedule once the sensor reports the matching new target', () => {
+  const inst = makeInstance({
+    states: {
+      'sensor.gaggiuino_local_profiler_machine_status': { attributes: {} },
+      'sensor.gaggiuino_local_profiler_preheat_ready_by_target_at': { state: '2026-07-28T08:00:00.000Z' },
+      'sensor.gaggiuino_local_profiler_preheat_planned_switch_on_at': { state: '2026-07-28T07:40:00.000Z' },
+    },
+  });
+  inst._pendingReadyByTargetAt = new Date('2026-07-28T08:00:00.000Z');
+  const { targetAt, plannedAt } = inst._readReadyBy();
+  assert.equal(targetAt.toISOString(), '2026-07-28T08:00:00.000Z');
+  assert.equal(plannedAt.toISOString(), '2026-07-28T07:40:00.000Z');
   assert.equal(inst._pendingReadyByTargetAt, null);
 });
 

--- a/test/token-sync.test.js
+++ b/test/token-sync.test.js
@@ -1,8 +1,15 @@
-// Local-dev-only consistency check: the GLP-TOKENS block (shared HA-theme hybrid
-// tokens + chart series palette) must stay byte-identical between this repo and
-// glp-order-card, so both cards render with the same hybrid theming contract.
-// Skips cleanly whenever there's nothing to compare yet: neighbor repo not
-// checked out, or checked out but without its own GLP-TOKENS block yet.
+// Consistency check for JS blocks intentionally kept byte-identical between
+// this repo and glp-order-card.js — originally just the GLP-TOKENS CSS
+// block, extended (#74) to the shared helpers that had already drifted
+// (esc/safeUrl, the machine-status matching predicate) without anyone
+// noticing, because the old version only ever compared the CSS block.
+//
+// "Neighbor repo not checked out" is a normal, expected state for local dev
+// (skip) but not for CI, which is expected to check the neighbor out
+// (see .github/workflows/validate.yml) — there, its absence means the
+// checkout step is broken and this fails instead of silently skipping.
+// A block missing on the neighbor's side (companion change not landed yet)
+// always skips, in CI or not — that's a legitimate transitional state.
 'use strict';
 
 const test = require('node:test');
@@ -11,43 +18,58 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-// Anchor on the short, stable prefix rather than the full marker sentence —
-// the marker's wording (currently naming both files) is itself part of the
-// compared block and must stay identical too, but the search anchor
-// shouldn't break if that wording is ever tweaked in lockstep on both sides.
-const START = '/* GLP-TOKENS v1';
-const END = '/* /GLP-TOKENS v1 */';
+// Overridable so CI can point this at wherever it checks out the neighbor
+// repo, without disturbing the local-dev default (a sibling checkout under
+// ~/Dokumente/Projekte/glp-project, per this machine's layout).
+const NEIGHBOR_PATH = process.env.GLP_ORDER_CARD_PATH
+  || path.join(os.homedir(), 'Dokumente', 'Projekte', 'glp-project', 'glp-order-card', 'glp-order-card.js');
 
-function extractTokenBlock(src) {
-  const startIdx = src.indexOf(START);
-  const endIdx = src.indexOf(END);
+const IN_CI = !!process.env.CI;
+
+const OWN_SRC = fs.readFileSync(path.join(__dirname, '..', 'glp-card.js'), 'utf8');
+
+// Anchored on a short, stable prefix rather than the full marker sentence —
+// the marker's wording (it names both files) is itself part of the compared
+// block and must stay identical too, but the search anchor shouldn't break
+// if that wording is ever tweaked in lockstep on both sides.
+const BLOCKS = [
+  { name: 'GLP-TOKENS v1',               start: '/* GLP-TOKENS v1',               end: '/* /GLP-TOKENS v1 */' },
+  { name: 'GLP-SHARED:esc v1',           start: '// GLP-SHARED:esc v1',           end: '// /GLP-SHARED:esc v1' },
+  { name: 'GLP-SHARED:safeUrl v1',       start: '// GLP-SHARED:safeUrl v1',       end: '// /GLP-SHARED:safeUrl v1' },
+  { name: 'GLP-SHARED:contrast v1',      start: '/* GLP-SHARED:contrast v1',      end: '/* /GLP-SHARED:contrast v1 */' },
+  { name: 'GLP-SHARED:machine-match v1', start: '// GLP-SHARED:machine-match v1', end: '// /GLP-SHARED:machine-match v1' },
+];
+
+function extractBlock(src, { start, end }) {
+  const startIdx = src.indexOf(start);
+  const endIdx = src.indexOf(end);
   if (startIdx === -1 || endIdx === -1) return null;
-  return src.slice(startIdx, endIdx + END.length);
+  return src.slice(startIdx, endIdx + end.length);
 }
 
-test('GLP-TOKENS block is byte-identical with glp-order-card.js (skips if neighbor repo/block absent)', (t) => {
-  const neighborPath = path.join(os.homedir(), 'Dokumente', 'Projekte', 'glp-project', 'glp-order-card', 'glp-order-card.js');
-  if (!fs.existsSync(neighborPath)) {
-    t.skip(`glp-order-card.js not found at ${neighborPath} — local-dev-only check, skipping`);
-    return;
-  }
+for (const block of BLOCKS) {
+  test(`${block.name} block is byte-identical with glp-order-card.js (fails in CI if the neighbor repo/block is missing)`, (t) => {
+    if (!fs.existsSync(NEIGHBOR_PATH)) {
+      const msg = `glp-order-card.js not found at ${NEIGHBOR_PATH}`;
+      if (IN_CI) { assert.fail(`${msg} — CI is expected to check out the neighbor repo for this test`); }
+      t.skip(`${msg} — local-dev-only check, skipping`);
+      return;
+    }
 
-  const ownSrc = fs.readFileSync(path.join(__dirname, '..', 'glp-card.js'), 'utf8');
-  const neighborSrc = fs.readFileSync(neighborPath, 'utf8');
+    const ownBlock = extractBlock(OWN_SRC, block);
+    assert.ok(ownBlock, `glp-card.js must contain a ${block.name} block`);
 
-  const ownBlock = extractTokenBlock(ownSrc);
-  const neighborBlock = extractTokenBlock(neighborSrc);
+    const neighborSrc = fs.readFileSync(NEIGHBOR_PATH, 'utf8');
+    const neighborBlock = extractBlock(neighborSrc, block);
+    if (!neighborBlock) {
+      // glp-order-card hasn't picked up this shared block yet — an expected
+      // transitional state (companion change not landed there), not a
+      // CI-worthy failure. Once it adds its own matching markers, this
+      // starts asserting the two stay byte-identical.
+      t.skip(`glp-order-card.js has no ${block.name} block yet — companion change not implemented, skipping`);
+      return;
+    }
 
-  assert.ok(ownBlock, 'glp-card.js must contain a GLP-TOKENS v1 block');
-
-  if (!neighborBlock) {
-    // glp-order-card hasn't picked up the shared contract yet (companion issue
-    // #39 not implemented) — nothing to compare against yet, so skip rather
-    // than fail. Once it adds its own GLP-TOKENS v1 block, this test starts
-    // asserting the two stay byte-identical.
-    t.skip('glp-order-card.js has no GLP-TOKENS v1 block yet — companion issue not implemented, skipping');
-    return;
-  }
-
-  assert.equal(neighborBlock, ownBlock, 'GLP-TOKENS block drifted between glp-card.js and glp-order-card.js');
-});
+    assert.equal(neighborBlock, ownBlock, `${block.name} block drifted between glp-card.js and glp-order-card.js`);
+  });
+}


### PR DESCRIPTION
## Summary

Three low/medium-priority findings from the 2026-07-28 ecosystem audit, all scoped to this repo.

- **#70**: `_readReadyBy()`'s pending-override clearing compared `realTargetAt` by truthiness only, so re-scheduling an already-active ready-by target could get the new pending value cleared prematurely by a render still seeing the old (stale or unavailable-cache) target. Now compares `realTargetAt.getTime() === this._pendingReadyByTargetAt.getTime()`.
- **#55**: Shot-card bean enrichment (`_beanExtraHtml()`) matched beans by free-text coffee name, the same bug class fixed app-side in `gaggiuino-local-profiler#456`. Now prefers the stable `beanId` (via a new `_beansInfoById` map), falling back to name matching for shots that predate it. Note: `shotObj.beanId` currently reads `undefined` until `glp-integration`'s `coordinator.py` threads `annotation.beanId` through the `recent_shots` sensor attribute — this change is forward-compatible and takes effect once that lands; falls back to name matching until then (flagging this as a follow-up, out of scope for this repo).
- **#74**: The token-sync test only covered the `GLP-TOKENS` CSS block and skipped silently whenever the neighbor repo (`glp-order-card`) wasn't checked out — the normal case in CI, so it never actually ran there. Two of the four other duplicated blocks (`safeUrl`, machine-status matching) had already drifted without this catching it. Wrapped the four helper blocks in `GLP-SHARED v1` markers, generalized `token-sync.test.js` to loop over all five marked blocks, made "neighbor not found at all" a CI failure (via the `CI` env var) instead of a skip, and added a CI step that checks out `glp-order-card` as a sibling directory. A block missing on the neighbor's side (companion change not landed there yet) still soft-skips regardless of CI — expected transitional state. `glp-order-card.js` itself isn't touched (out of scope for this repo); its `_safeUrl()` and machine-matching predicate still need a companion PR there to actually re-sync.

## Test plan
- [x] `npm test` — 52 pass, 4 expected skips (companion blocks not yet in `glp-order-card`), 0 fail
- [x] `npm run lint` — 0 errors (2 pre-existing `innerHTML` warnings, unrelated)
- [x] `npm run build` — syntax check clean
- [x] Manually verified the new CI-failure path (`CI=true` + bad `GLP_ORDER_CARD_PATH` → hard fail) and the CI-pass path (`CI=true` + real neighbor path → same skip/pass split as local dev)

Closes #70, #55, #74

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>