### PR TITLE
Center logo.svg text block vertically in banner

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -20,17 +20,17 @@
   <line x1="138" y1="24" x2="138" y2="131" stroke="#3f3f46" stroke-width="1.5"/>
 
   <!-- GLP wordmark -->
-  <text x="162" y="97"
+  <text x="162" y="83"
         font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif"
         font-size="68" font-weight="800" fill="white" letter-spacing="-2">GLP</text>
 
   <!-- Subtitle: product name -->
-  <text x="165" y="116"
+  <text x="165" y="102"
         font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif"
         font-size="12" font-weight="500" fill="#71717a" letter-spacing="3.5">GAGGIUINO LOCAL PROFILER</text>
 
   <!-- Subtitle: integration badge -->
-  <text x="165" y="134"
+  <text x="165" y="120"
         font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif"
         font-size="10" font-weight="500" fill="#41bdf5" letter-spacing="2.5">HOME ASSISTANT LOVELACE CARD</text>
 


### PR DESCRIPTION
## Summary
- The GLP wordmark and its two subtitle lines in `logo.svg` were pushed toward the bottom of the banner instead of sitting centered between the top and bottom edges.
- Shifted all three `<text>` y-coordinates up by 14px so the block is centered on the box (verified via the already-centered divider/icon midpoint).

## Test plan
- [x] Opened `logo.svg` and visually confirmed the text block is centered