### PR TITLE
ci: pin Scorecard workflow actions to commit SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,25 +22,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- `ossf/scorecard-action@v2` doesn't resolve — the action only ever published fully qualified `v2.x.x` tags, never a floating `v2` major tag — which has failed every Scorecard run in this repo since 2026-08-02, unrelated to any app code.
- Pins all four actions in `.github/workflows/scorecard.yml` to commit SHA, matching the already-pinned convention in the sibling repos (gaggiuino-local-profiler, glp-order-card, glp-integration).

Closes #89

## Test plan
- [x] Verified via `gh api repos/ossf/scorecard-action/tags` that no `v2` tag exists, only `v2.x.x`
- [x] Confirmed sibling repos already use the exact same SHA pins for all four actions
- [ ] CI on this PR (the Scorecard workflow itself doesn't run on PRs, only push-to-main/schedule — verify via the next scheduled/push run after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)