### PR TITLE
chore(deps): bump brace-expansion to 5.0.9 (DoS fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -360,9 +360,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes CodeQL/Scorecard alert (Vulnerabilities, high) — https://osv.dev/GHSA-rgw5-rvv9-x895.

Transitive dev dependency via ESLint's minimatch. The maxLength mitigation added upstream in brace-expansion 5.0.8 for CVE-2026-14257 was incomplete (bounded the combined accumulator but not intermediate arrays feeding it, so a ~25KB crafted input still crashes with an uncatchable OOM). 5.0.9 fixes the remaining path.

Dev-only — not part of the shipped card code, no runtime impact.

## Test plan
- [x] `npm test` — 66/66 (4 skipped, expected: order-card companion blocks not implemented yet)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [x] `npm audit` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)