### PR TITLE
ci: pin workflow actions to commit SHA, add token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
     - cron: "0 3 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (javascript-typescript)
@@ -19,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,16 +9,19 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   hacs:
     name: HACS
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: HACS validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: plugin
 
@@ -28,7 +31,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Fetch glp-order-card.js for shared-block sync test (#74)
         # Only the raw file is needed (byte comparison of marked blocks) --
@@ -40,7 +43,7 @@ jobs:
         run: curl -fsSL -o "${{ runner.temp }}/glp-order-card.js" https://raw.githubusercontent.com/mxkissnr/glp-order-card/main/glp-order-card.js
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 20
           cache: 'npm'


### PR DESCRIPTION
Closes #93. Resolves 11 CodeQL/Scorecard findings (TokenPermissionsID ×2, PinnedDependenciesID ×9) in `validate.yml`/`codeql.yml`/`dependency-review.yml` — pure CI-config hardening, no behavior change. Same SHAs the sibling `glp-order-card` repo already uses.

## Test plan
- [x] `npm test` — 66/66 (4 skipped, expected)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [x] YAML validity checked for all three edited workflow files
- [ ] CI — verify green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)