### PR TITLE
ci: add npm audit gate, harden external link with rel=noopener

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
       - name: Lint
         run: npm run lint
 

--- a/glp-card.js
+++ b/glp-card.js
@@ -2292,7 +2292,7 @@ class GlpCard extends HTMLElement {
         ${waterLevel !== null ? `<span class="footer-item">💧 ${waterLevel}%</span>` : '<span></span>'}
         <span class="footer-item">
           ${syncTime ? `${syncTime}` : ''}
-          ${glpUrl ? `${syncTime ? ' · ' : ''}<a href="${esc(glpUrl)}" target="_blank">GLP ↗</a>` : ''}
+          ${glpUrl ? `${syncTime ? ' · ' : ''}<a href="${esc(glpUrl)}" target="_blank" rel="noopener noreferrer">GLP ↗</a>` : ''}
         </span>
       </div>`;
 


### PR DESCRIPTION
Closes #100.

Three small, independent security-hardening points from a GLP-ecosystem review:

1. **`npm audit` CI gate**: `validate.yml` ran HACS validation, lint, tests, and build, but never checked the committed `package-lock.json` against known vulnerabilities — `dependency-review-action` only checks PR diffs, not the existing dependency set. Added `npm audit --audit-level=high` after `npm ci`. The card ships no runtime dependencies (devDependencies only: eslint, playwright, c8, ...), so this is a defense-in-depth net for the dev toolchain.
2. **CodeQL action pinning**: already resolved on `main` — `codeql-action/analyze` is SHA-pinned to the same commit as `init` (`f205ea1...` / v4) since #94. Verified, no change needed.
3. **`rel="noopener noreferrer"`**: added to the GLP-link footer anchor (`target="_blank"`) in `glp-card.js` to prevent tabnabbing. Not an XSS risk — the URL is the card's own YAML config, not backend-sourced data.

## Test plan
- [x] `npm run lint` — 0 errors (2 pre-existing innerHTML warnings, unrelated)
- [x] `npm run test:coverage` — 66/66 passing
- [x] `npm run build` — passes
- [x] `npm audit --audit-level=high` locally — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)