### PR TITLE
feat: sync accent theme from the app's Settings → Machines picker (v2.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.19.0] – 2026-08-09
+### Added
+- **The card now syncs its accent color to the app's own Settings → Machines theme picker** instead of only its standalone `theme`/`accent_color`/`accent_gradient` YAML config (#104, part of gaggiuino-local-profiler#701). `_resolveMachineTheme()` first looks up this card's own machine's `theme` from `hass` state — `glp-integration` forwards it verbatim off the app's `GET /api/status` `machines[]` array (gaggiuino-local-profiler#701 + glp-integration#128) — and only falls back to the YAML config when the app has no theme set for that machine (e.g. this card's zero-config/standalone mode, or an older app version). Reactive: since `_applyMachineTheme()` already re-runs on every `hass` push, changing the theme in the app now updates the card without a dashboard reload. New `GLP-SHARED:app-theme-lookup v1` block, kept byte-identical with glp-order-card.js. Closes #104
+
 ## [2.18.1] – 2026-08-04
 ### Security
 - **CI now gates on `npm audit --audit-level=high`** after `npm ci` in `validate.yml`, catching known vulnerabilities in the committed `package-lock.json` — `dependency-review-action` only checks PR diffs, not the existing dependency set. The card itself ships no runtime dependencies (devDependencies only: eslint, playwright, c8). `.github/workflows/validate.yml`. Closes #100

--- a/glp-card.js
+++ b/glp-card.js
@@ -1,4 +1,4 @@
-const GLP_CARD_VERSION = '2.18.1';
+const GLP_CARD_VERSION = '2.19.0';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
 // DE wording is the original card text; language follows hass.language (DE/EN/IT/FR/ES/NL, falls back to EN).
@@ -1631,8 +1631,8 @@ class GlpCard extends HTMLElement {
   // custom #rrggbb), and `accent_gradient` (a [start, end] #rrggbb pair) —
   // see _resolveMachineTheme(). These mirror the GLP app's `machines.theme`
   // storage contract (gaggiuino-local-profiler#595) as this card's
-  // standalone/no-app YAML fallback; once a card-to-app sync exists (a later
-  // round), the app's own stored theme will take precedence over these.
+  // standalone/no-app YAML fallback; the app's own stored theme (#701, see
+  // _appMachineTheme() below) takes precedence over these once available.
   setConfig(config) {
     this._config = { title: 'Gaggiuino', ...config };
     // Re-resolve the switch entity from the machine-scoped storage key now
@@ -1642,14 +1642,62 @@ class GlpCard extends HTMLElement {
       || localStorage.getItem('glp_switch_entity') || null;
   }
 
-  // Resolves this card's optional theme config (#87) to a {a,b} hex pair, or
-  // null when nothing valid is configured (falls back to the default
-  // --glp-accent-start/-end = --glp-accent behavior). Precedence, matching
-  // "more specific wins": accent_gradient > accent_color > theme preset key.
-  // Strict hex validation only (HEX_COLOR_RE) — operator-set YAML, not
-  // attacker input, but never let an unvalidated string reach a style
-  // attribute regardless of source.
+  // GLP-SHARED:app-theme-lookup v1 — reads this card's own machine's
+  // app-stored theme (#701) out of `hass` state, or null when unavailable
+  // (no app-side sync yet, e.g. this card's zero-config/standalone mode).
+  // glp-integration forwards every machine's `theme` verbatim off the app's
+  // GET /api/status `machines[]` (gaggiuino-local-profiler#701): any
+  // `*_machine_status`-suffixed entity carries the WHOLE array (every
+  // machine, not just the default one) as its `machines` attribute, so any
+  // one such entity is enough regardless of which machine this card
+  // instance represents. Matched against `this._config.machine` the same
+  // "name or id" needle way this card's own machine-status-entity matching
+  // works, falling back to the isDefault entry when unconfigured. Kept
+  // byte-identical between glp-card.js and glp-order-card.js.
+  _appMachineTheme() {
+    if (!this._hass) return null;
+    const statusIds = Object.keys(this._hass.states).filter(id => id.endsWith('_machine_status'));
+    let machines = null;
+    for (const id of statusIds) {
+      const list = this._hass.states[id]?.attributes?.machines;
+      if (Array.isArray(list)) { machines = list; break; }
+    }
+    if (!machines) return null;
+    let entry = null;
+    if (this._config?.machine) {
+      const needle = String(this._config.machine).toLowerCase();
+      entry = machines.find(m =>
+        String(m.name || '').toLowerCase() === needle || String(m.id) === needle);
+    }
+    if (!entry) entry = machines.find(m => m.isDefault) || null;
+    const theme = entry?.theme;
+    if (!theme) return null;
+    if (typeof theme.preset === 'string' && Object.prototype.hasOwnProperty.call(THEME_PRESETS, theme.preset)) {
+      return THEME_PRESETS[theme.preset];
+    }
+    // Inline literal regex (not each file's own HEX_COLOR_RE/_validHex) so
+    // this shared block stays byte-identical regardless of what either
+    // file's local hex-validation helper happens to be named.
+    if (/^#[0-9a-fA-F]{6}$/.test(theme.a) && /^#[0-9a-fA-F]{6}$/.test(theme.b)) {
+      return { a: theme.a, b: theme.b };
+    }
+    return null;
+  }
+  // /GLP-SHARED:app-theme-lookup v1
+
+  // Resolves this card's effective theme to a {a,b} hex pair, or null when
+  // nothing valid is configured/synced (falls back to the default
+  // --glp-accent-start/-end = --glp-accent behavior). The app's own stored
+  // theme (#701, _appMachineTheme()) takes precedence over this card's YAML
+  // config, matching the precedence already promised in setConfig()'s
+  // comment. YAML precedence among itself, matching "more specific wins":
+  // accent_gradient > accent_color > theme preset key. Strict hex
+  // validation only (HEX_COLOR_RE) — operator-set YAML, not attacker input,
+  // but never let an unvalidated string reach a style attribute regardless
+  // of source.
   _resolveMachineTheme() {
+    const fromApp = this._appMachineTheme();
+    if (fromApp) return fromApp;
     const cfg = this._config || {};
     if (Array.isArray(cfg.accent_gradient) && cfg.accent_gradient.length === 2 &&
         HEX_COLOR_RE.test(cfg.accent_gradient[0]) && HEX_COLOR_RE.test(cfg.accent_gradient[1])) {

--- a/test/machine-theme.test.js
+++ b/test/machine-theme.test.js
@@ -36,9 +36,10 @@ function loadGlpCard() {
 
 const GlpCard = loadGlpCard();
 
-function makeInstance(config) {
+function makeInstance(config, hass) {
   const inst = Object.create(GlpCard.prototype);
   inst._config = config;
+  inst._hass = hass;
   inst.style = makeStyleStub();
   return inst;
 }
@@ -115,4 +116,61 @@ test('_applyMachineTheme() clears any previously-set inline override when no the
   inst._applyMachineTheme();
   assert.equal(inst.style.getPropertyValue('--glp-accent-start'), '');
   assert.equal(inst.style.getPropertyValue('--glp-accent-end'), '');
+});
+
+// #701 — app-synced theme (via hass state) takes precedence over this
+// card's own YAML config.
+test('_appMachineTheme() returns null with no hass set (standalone/no-app-sync mode, unchanged pre-#701 behavior)', () => {
+  assert.equal(makeInstance({})._appMachineTheme(), null);
+});
+
+test('_appMachineTheme() returns null when no *_machine_status entity carries a machines[] attribute', () => {
+  const hass = { states: { 'sensor.gaggiuino_local_profiler_machine_status': { attributes: {} } } };
+  assert.equal(makeInstance({}, hass)._appMachineTheme(), null);
+});
+
+test('_appMachineTheme() resolves the isDefault machine\'s theme when `machine` is not configured', () => {
+  const hass = { states: { 'sensor.gaggiuino_local_profiler_machine_status': { attributes: { machines: [
+    { id: 1, name: 'Gaggiuino', isDefault: true, theme: { preset: 'twilight-turkish' } },
+    { id: 2, name: 'Kitchen GaggiMate', isDefault: false, theme: { preset: 'ember-espresso' } },
+  ] } } } };
+  assertTheme(makeInstance({}, hass)._appMachineTheme(), '#0891b2', '#4338ca');
+});
+
+test('_appMachineTheme() resolves the machine matching `_config.machine` by name', () => {
+  const hass = { states: { 'sensor.gaggiuino_local_profiler_machine_status': { attributes: { machines: [
+    { id: 1, name: 'Gaggiuino', isDefault: true, theme: null },
+    { id: 2, name: 'Kitchen GaggiMate', isDefault: false, theme: { preset: 'ember-espresso' } },
+  ] } } } };
+  assertTheme(makeInstance({ machine: 'Kitchen GaggiMate' }, hass)._appMachineTheme(), '#dc4a1f', '#f5a623');
+});
+
+test('_appMachineTheme() resolves a custom {a,b} theme', () => {
+  const hass = { states: { 'sensor.gaggiuino_local_profiler_machine_status': { attributes: { machines: [
+    { id: 1, name: 'Gaggiuino', isDefault: true, theme: { a: '#111111', b: '#222222' } },
+  ] } } } };
+  assertTheme(makeInstance({}, hass)._appMachineTheme(), '#111111', '#222222');
+});
+
+test('_appMachineTheme() rejects a malformed custom theme from hass state', () => {
+  const hass = { states: { 'sensor.gaggiuino_local_profiler_machine_status': { attributes: { machines: [
+    { id: 1, name: 'Gaggiuino', isDefault: true, theme: { a: 'not-hex', b: '#222222' } },
+  ] } } } };
+  assert.equal(makeInstance({}, hass)._appMachineTheme(), null);
+});
+
+test('_resolveMachineTheme(): the app-synced theme wins over this card\'s own YAML config', () => {
+  const hass = { states: { 'sensor.gaggiuino_local_profiler_machine_status': { attributes: { machines: [
+    { id: 1, name: 'Gaggiuino', isDefault: true, theme: { preset: 'twilight-turkish' } },
+  ] } } } };
+  const inst = makeInstance({ theme: 'ember-espresso' }, hass);
+  assertTheme(inst._resolveMachineTheme(), '#0891b2', '#4338ca');
+});
+
+test('_resolveMachineTheme(): falls back to YAML config when the app has no theme set for this machine', () => {
+  const hass = { states: { 'sensor.gaggiuino_local_profiler_machine_status': { attributes: { machines: [
+    { id: 1, name: 'Gaggiuino', isDefault: true, theme: null },
+  ] } } } };
+  const inst = makeInstance({ theme: 'ember-espresso' }, hass);
+  assertTheme(inst._resolveMachineTheme(), '#dc4a1f', '#f5a623');
 });

--- a/test/token-sync.test.js
+++ b/test/token-sync.test.js
@@ -38,6 +38,7 @@ const BLOCKS = [
   { name: 'GLP-SHARED:safeUrl v1',       start: '// GLP-SHARED:safeUrl v1',       end: '// /GLP-SHARED:safeUrl v1' },
   { name: 'GLP-SHARED:contrast v1',      start: '/* GLP-SHARED:contrast v1',      end: '/* /GLP-SHARED:contrast v1 */' },
   { name: 'GLP-SHARED:machine-match v1', start: '// GLP-SHARED:machine-match v1', end: '// /GLP-SHARED:machine-match v1' },
+  { name: 'GLP-SHARED:app-theme-lookup v1', start: '// GLP-SHARED:app-theme-lookup v1', end: '// /GLP-SHARED:app-theme-lookup v1' },
 ];
 
 function extractBlock(src, { start, end }) {


### PR DESCRIPTION
## Summary
- Part of the cross-repo plan in gaggiuino-local-profiler#701: syncs this card's accent color to the app's own Settings → Machines theme picker instead of only its standalone YAML config.
- `_resolveMachineTheme()` now first tries `_appMachineTheme()` (reads this card's own machine's `theme` from `hass` state via the `machines[]` attribute `glp-integration` already forwards) and only falls back to the existing `theme`/`accent_color`/`accent_gradient` YAML keys when the app has no theme set for that machine.
- Reactive with no extra wiring — `_applyMachineTheme()` already re-runs on every `hass` push.
- New `GLP-SHARED:app-theme-lookup v1` block, byte-identical with the companion change in glp-order-card (mxkissnr/glp-order-card#74).

Closes #104

## Test plan
- [x] `npm test` — 75 passed (8 new), including the `GLP-SHARED:app-theme-lookup v1` cross-repo byte-identity check
- [x] `npm run build` — syntax check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)