### PR TITLE
Empty the TRANSITIONAL list now that #114/glp-order-card#84 have merged

### DIFF
--- a/test/token-sync.test.js
+++ b/test/token-sync.test.js
@@ -65,18 +65,16 @@ const BLOCKS = [
 // companion PR only. Every entry MUST carry an issue reference — an entry
 // without one is a bug, and the file refuses to load if it finds one (see
 // the validation loop below). The list MUST be emptied immediately once the
-// named companion PR(s) merge — see #115, which tracks doing exactly that.
+// named companion PR(s) merge (#115 tracked this repo's post-#114 cleanup).
 // A non-empty TRANSITIONAL outside of an active cross-repo merge window
 // means the guard is silently checking less than it claims to, exactly the
 // failure mode #113 was filed to fix in the first place.
-const TRANSITIONAL = {
-  'GLP-SHARED:esc v1':           { issue: '#113', reason: 'companion PR mxkissnr/glp-order-card#84 adds this marker there; not on glp-order-card main yet' },
-  'GLP-SHARED:safeUrl v1':       { issue: '#113', reason: 'companion PR mxkissnr/glp-order-card#84 adds this marker there; not on glp-order-card main yet' },
-  'GLP-SHARED:theme-presets v1': { issue: '#113', reason: 'companion PR mxkissnr/glp-order-card#84 adds this marker there; not on glp-order-card main yet' },
-  'GLP-SHARED:machine-icon v1':  { issue: '#113', reason: 'companion PR mxkissnr/glp-order-card#84 adds this marker there; not on glp-order-card main yet' },
-  'GLP-SHARED:contrast v1':      { issue: '#113', reason: 'companion PR mxkissnr/glp-order-card#84 adds this marker there; not on glp-order-card main yet' },
-  'GLP-SHARED:machine-match v1': { issue: '#113', reason: 'companion PR mxkissnr/glp-order-card#84 adds this marker there; not on glp-order-card main yet' },
-};
+//
+// Normal state: EMPTY. Populate it only while a companion PR that changes a
+// GLP-SHARED block is open on the neighbor repo, and empty it again in the
+// same round that companion PR merges — see #115 for the shape that
+// cleanup PR takes.
+const TRANSITIONAL = {};
 
 for (const [name, entry] of Object.entries(TRANSITIONAL)) {
   if (!entry || !entry.issue) {


### PR DESCRIPTION
Closes #115.

## Summary

The cross-repo merge window is closed: #114 and the companion
mxkissnr/glp-order-card#84 are both on their respective `main` branches now,
so `TRANSITIONAL` in `test/token-sync.test.js` no longer has a reason to
exempt anything. Emptied it back to `{}`, kept the explanatory comment and
the "issue-reference required" validation loop intact (with an added note
that the normal state is empty), so the mechanism stays discoverable and
enforced the next time a shared block actually needs it.

## Verification (the point of this PR)

Ran the strict check with the escape hatch empty, against the **real,
current** glp-order-card `main` (not the merged PR branch — fetched fresh
via `git fetch`/`origin/main`):

```
✔ GLP-TOKENS v1 block is byte-identical with glp-order-card.js
✔ GLP-SHARED:esc v1 block is byte-identical with glp-order-card.js
✔ GLP-SHARED:safeUrl v1 block is byte-identical with glp-order-card.js
✔ GLP-SHARED:theme-presets v1 block is byte-identical with glp-order-card.js
✔ GLP-SHARED:machine-icon v1 block is byte-identical with glp-order-card.js
✔ GLP-SHARED:contrast v1 block is byte-identical with glp-order-card.js
✔ GLP-SHARED:machine-match v1 block is byte-identical with glp-order-card.js
✔ GLP-SHARED:app-theme-lookup v1 block is byte-identical with glp-order-card.js
tests 81, pass 81, fail 0, skipped 0
```

All 8 checks pass — 0 skipped, 0 failed. This is the first time this test
has ever run the strict comparison across all seven GLP-SHARED blocks with
nothing exempted. **No drift found.**

## Test plan
- [x] `npm run test:coverage` against real glp-order-card `main` (81/81
      tests, coverage 57.41% > 53% gate)
- [x] `npm run lint` (0 errors, pre-existing innerHTML warnings only)
- [x] `npm run build`