### PR TITLE
Add Playwright E2E smoke suite on top of the screenshot harness

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Audit dependencies
         run: npm audit --audit-level=high
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Lint
         run: npm run lint
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,7 @@ module.exports = [
     rules: commonRules,
   },
   {
-    files: ['test/**/*.js'],
+    files: ['test/**/*.js', 'test/**/*.mjs'],
     languageOptions: {
       globals: globals.node,
     },

--- a/scripts/e2e-harness.mjs
+++ b/scripts/e2e-harness.mjs
@@ -1,0 +1,38 @@
+// Shared browser-test scaffolding: a throwaway http.createServer serving
+// this repo's root (so glp-card.js can be loaded without file:// CORS
+// issues) plus a `/__harness.html` route. Used by both scripts/screenshot.mjs
+// (README screenshots) and test/e2e/smoke.test.mjs (Playwright E2E smoke
+// test) so the two don't duplicate this setup — mirrors glp-order-card's
+// scripts/e2e-harness.mjs (same pattern, kept independent per repo since the
+// two cards' mock-data shapes differ enough that a shared module would just
+// add indirection).
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const repoRoot = path.join(__dirname, '..');
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.svg': 'image/svg+xml', '.png': 'image/png' };
+
+export function startServer(harnessHtml) {
+  const server = http.createServer((req, res) => {
+    const urlPath = req.url.split('?')[0];
+    if (urlPath === '/__harness.html') {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(harnessHtml);
+      return;
+    }
+    const filePath = path.join(repoRoot, decodeURIComponent(urlPath));
+    if (!filePath.startsWith(repoRoot)) { res.writeHead(403); res.end(); return; }
+    fs.readFile(filePath, (err, data) => {
+      if (err) { res.writeHead(404); res.end('not found'); return; }
+      const ext = path.extname(filePath);
+      res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+      res.end(data);
+    });
+  });
+  return new Promise(resolve => server.listen(0, '127.0.0.1', () => resolve(server)));
+}

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -34,11 +34,10 @@
 // --machine-off).
 // Requires `npx playwright install chromium` once beforehand.
 
-import http from 'node:http';
 import path from 'node:path';
-import { mkdirSync, readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { mkdirSync } from 'node:fs';
 import { chromium } from 'playwright';
+import { repoRoot, startServer } from './e2e-harness.mjs';
 
 function flag(name, envVar, fallback) {
     const eq = process.argv.find(a => a.startsWith(`--${name}=`));
@@ -47,8 +46,6 @@ function flag(name, envVar, fallback) {
     return fallback;
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot  = path.join(__dirname, '..');
 const outDir    = path.join(repoRoot, 'docs', 'screenshots');
 const LIGHT_SHORTHAND = process.argv.includes('--light');
 const MACHINE_OFF = process.argv.includes('--machine-off');
@@ -58,7 +55,6 @@ const defaultOutName = MACHINE_OFF
   ? 'card-ready-by.png'
   : (HA_THEME === 'light' ? 'card-light.png' : 'card.png');
 const outFile   = flag('out', '', path.join(outDir, defaultOutName));
-const PORT      = 8321;
 
 // HA theme CSS variables the card reads via the GLP-TOKENS fallback chain.
 // Values match the "GLP Light"/"GLP Dark" themes in glp-ha-theme.yaml.
@@ -196,28 +192,9 @@ ${THEME_VARS}  }
 </body>
 </html>`;
 
-function startServer() {
-    return new Promise(resolve => {
-        const server = http.createServer((req, res) => {
-            if (req.url === '/' || req.url === '/index.html') {
-                res.writeHead(200, { 'Content-Type': 'text/html' });
-                res.end(PAGE_HTML);
-                return;
-            }
-            if (req.url === '/glp-card.js') {
-                res.writeHead(200, { 'Content-Type': 'text/javascript' });
-                res.end(readFileSync(path.join(repoRoot, 'glp-card.js'), 'utf8'));
-                return;
-            }
-            res.writeHead(404);
-            res.end();
-        });
-        server.listen(PORT, () => resolve(server));
-    });
-}
-
 async function main() {
-    const server = await startServer();
+    const server = await startServer(PAGE_HTML);
+    const { port } = server.address();
     const browser = await chromium.launch();
     try {
         // colorScheme is intentionally independent from HA_THEME/THEME_VARS —
@@ -230,7 +207,7 @@ async function main() {
             viewport: { width: 460, height: 900 },
             colorScheme: OS_SCHEME === 'light' ? 'light' : 'dark',
         });
-        await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'load' });
+        await page.goto(`http://127.0.0.1:${port}/__harness.html`, { waitUntil: 'load' });
         await page.waitForTimeout(500);
         const card = page.locator('#card');
         await card.waitFor({ state: 'attached' });

--- a/test/e2e/smoke.test.mjs
+++ b/test/e2e/smoke.test.mjs
@@ -1,0 +1,159 @@
+// Minimal Playwright E2E smoke test. Reuses the static-server harness from
+// scripts/e2e-harness.mjs (shared with scripts/screenshot.mjs) to render the
+// real glp-card.js in a headless Chromium tab -- not a vm sandbox -- so it
+// can exercise real custom-element lifecycle, shadow DOM and pointerdown
+// event wiring that vm.runInContext-based unit tests structurally can't
+// reach. Mirrors glp-order-card's test/e2e/smoke.test.mjs (same harness
+// shape, same npm test auto-discovery via test/**/*.test.mjs).
+//
+// Covers three things pure unit tests can't: (1) the card actually mounts
+// and renders real DOM in a browser, (2) a switch entity going
+// 'unavailable' collapses to the defined off-card branch instead of
+// throwing, and (3) the ready-by optimistic-UI guard (_pendingReadyByTargetAt,
+// see glp-card.js's _readReadyBy()) survives a concurrently-arriving `hass`
+// push wired through the *real* pointerdown handler and _render() -- the
+// exact bug class (#66/#68/#70) that ready-by.test.js covers in isolation
+// on the pure _readReadyBy()/_resolveReadyByTarget() functions, but can't
+// prove is actually connected end-to-end.
+'use strict';
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+import { startServer } from '../../scripts/e2e-harness.mjs';
+
+const PREFIX = 'sensor.gaggiuino_local_profiler_';
+
+function buildMockStates({ switchState = 'on', readyByTarget = 'unknown' } = {}) {
+  const now = Date.now();
+  return {
+    [PREFIX + 'machine_status']: {
+      state: 'online',
+      attributes: {
+        switch_entity: 'switch.gaggiuino_local_profiler_machine',
+        recent_shots: [{ id: 1, profile: 'Standard Espresso', coffee: 'Bombe', drink_type: 'Espresso' }],
+      },
+    },
+    'switch.gaggiuino_local_profiler_machine': {
+      state: switchState,
+      last_changed: new Date(now - 3600 * 1000).toISOString(),
+      attributes: {},
+    },
+    [PREFIX + 'preheat_ready_by_target_at']:      { state: readyByTarget, attributes: {} },
+    [PREFIX + 'preheat_planned_switch_on_at']:    { state: 'unknown', attributes: {} },
+  };
+}
+
+function harnessHtml(mockStates) {
+  return `<!doctype html>
+<html><head><meta charset="utf-8"></head>
+<body>
+<div id="wrap"><glp-card id="card"></glp-card></div>
+<script type="module" src="/glp-card.js"></script>
+<script type="module">
+  const mockStates = ${JSON.stringify(mockStates)};
+  const card = document.getElementById('card');
+  card.setConfig({ title: 'Gaggiuino', entity_prefix: '${PREFIX}' });
+  card.hass = { language: 'de', states: mockStates, callService: () => {} };
+</script>
+</body></html>`;
+}
+
+// The page.evaluate()/waitForFunction() callbacks below run inside the
+// browser tab via Playwright, not in this Node process -- `document` is a
+// real global there, even though ESLint's static analysis (correctly, for
+// a .mjs Node test file) doesn't know that.
+/* eslint-disable no-undef */
+
+async function setUpCard(mockStates, readySelector) {
+  const server = await startServer(harnessHtml(mockStates));
+  const { port } = server.address();
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('pageerror', err => pageErrors.push(err));
+  await page.goto(`http://127.0.0.1:${port}/__harness.html`);
+  await page.waitForFunction(sel => {
+    const el = document.querySelector('glp-card');
+    return !!el?.shadowRoot?.querySelector(sel);
+  }, readySelector, { timeout: 10000 });
+  return { server, browser, page, pageErrors };
+}
+
+async function tearDown({ server, browser }) {
+  await browser.close();
+  server.close();
+}
+
+test('card renders the hero view with a realistic mocked hass', async () => {
+  const ctx = await setUpCard(buildMockStates(), '.shot-profile');
+  const { page, pageErrors } = ctx;
+  try {
+    const profileText = await page.evaluate(() =>
+      document.querySelector('glp-card').shadowRoot.querySelector('.shot-profile').textContent);
+    assert.equal(profileText, 'Standard Espresso');
+    assert.deepEqual(pageErrors, []);
+  } finally {
+    await tearDown(ctx);
+  }
+});
+
+test('switch entity going unavailable collapses to the off-card without throwing', async () => {
+  const ctx = await setUpCard(buildMockStates({ switchState: 'unavailable' }), '.card.collapsed');
+  const { page, pageErrors } = ctx;
+  try {
+    const offLabelShown = await page.evaluate(() =>
+      !!document.querySelector('glp-card').shadowRoot.querySelector('.off-label'));
+    assert.equal(offLabelShown, true);
+    assert.deepEqual(pageErrors, [], 'an unavailable switch entity must not throw during render');
+  } finally {
+    await tearDown(ctx);
+  }
+});
+
+test('a concurrent hass update does not clobber an in-progress ready-by pick', async () => {
+  const ctx = await setUpCard(buildMockStates({ switchState: 'off' }), '.ready-by-picker');
+  const { page, pageErrors } = ctx;
+  try {
+    await page.locator('#glp-readyby-input').fill('07:30');
+    // Real pointerdown-driven click (the card binds its action handlers on
+    // 'pointerdown', not 'click' -- a page.evaluate(() => el.click()) would
+    // silently no-op here since the native .click() method never dispatches
+    // pointerdown).
+    await page.locator('[data-action="set-ready-by"]').click();
+
+    await page.waitForFunction(() => {
+      const el = document.querySelector('glp-card');
+      return !!el?.shadowRoot?.querySelector('.ready-by-set');
+    }, { timeout: 5000 });
+
+    const pendingAfterClick = await page.evaluate(() =>
+      !!document.querySelector('glp-card')._pendingReadyByTargetAt);
+    assert.equal(pendingAfterClick, true, 'optimistic target is set right after the click');
+
+    // Simulate a hass push landing before the backend has confirmed the new
+    // schedule (preheat_ready_by_target_at still 'unknown') -- the exact
+    // race #66/#70 guard against: a concurrently-arriving hass update must
+    // not wipe the just-picked, still-unconfirmed target.
+    await page.evaluate(mockStates => {
+      const el = document.querySelector('glp-card');
+      el.hass = { language: 'de', states: mockStates, callService: () => {} };
+    }, buildMockStates({ switchState: 'off' }));
+
+    const state = await page.evaluate(() => {
+      const el = document.querySelector('glp-card');
+      return {
+        pendingTargetAt: !!el._pendingReadyByTargetAt,
+        readySetShown: !!el.shadowRoot.querySelector('.ready-by-set'),
+        pickerShown: !!el.shadowRoot.querySelector('.ready-by-picker'),
+      };
+    });
+    assert.equal(state.pendingTargetAt, true, 'pending target survives the concurrent hass push');
+    assert.equal(state.readySetShown, true, 'still shows the set/cancel view, not reverted to the picker');
+    assert.equal(state.pickerShown, false);
+    assert.deepEqual(pageErrors, []);
+  } finally {
+    await tearDown(ctx);
+  }
+});
+/* eslint-enable no-undef */


### PR DESCRIPTION
## Summary
- Extracts `scripts/e2e-harness.mjs` (static file server + `/__harness.html` route) out of `scripts/screenshot.mjs`, mirroring glp-order-card's existing `scripts/e2e-harness.mjs` pattern — the screenshot script now reuses it instead of running its own server.
- Adds `test/e2e/smoke.test.mjs`: three Playwright tests that render the real `glp-card.js` in headless Chromium (not the `vm.runInContext()`-sandboxed unit tests), so they exercise real custom-element lifecycle, shadow DOM, and `pointerdown`-bound event handlers:
  - the card renders the hero view with a realistic mocked `hass`
  - a switch entity going `unavailable` collapses to the defined off-card state instead of breaking
  - the ready-by optimistic-UI guard (`_pendingReadyByTargetAt` / `_readReadyBy()`) survives a `hass` update arriving mid-interaction — the real bug class behind #66/#68/#70
- `eslint.config.js`: added `test/**/*.mjs` to the test-file glob (only `.js` was covered before).
- `.github/workflows/validate.yml`: installs Chromium (`npx playwright install --with-deps chromium`) before running tests, matching glp-order-card's CI job.

Closes #118.

## Test plan
- [x] `npm run lint` — clean (2 pre-existing `innerHTML` warnings only)
- [x] `npm run test:coverage` — 84/84 passing locally (with `GLP_ORDER_CARD_PATH` pointed at a real sibling checkout for the token-sync test), 57.4% line coverage vs. the 53% gate
- [x] `node --test test/e2e/smoke.test.mjs` run standalone — 3/3 passing, ~250-350ms each
- [x] `npm run build` (syntax check)
- [x] `npm run screenshot` still produces `docs/screenshots/card.png` after the harness refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)