### PR TITLE
Empty TRANSITIONAL after the redesign merge

### DIFF
--- a/test/token-sync.test.js
+++ b/test/token-sync.test.js
@@ -75,16 +75,7 @@ const BLOCKS = [
 // GLP-SHARED block is open on the neighbor repo, and empty it again in the
 // same round that companion PR merges — see #115 for the shape that
 // cleanup PR takes.
-const TRANSITIONAL = {
-  // ACTIVE MERGE WINDOW — the "Instrument" redesign changes three shared
-  // blocks at once, in glp-order-card#91 and glp-lovelace-card#121 together.
-  // CI resolves the neighbour file from its default branch, so until BOTH
-  // land each PR compares its new block against the other repo main's old
-  // one. Remove all three the moment both have merged — tracked as mxkissnr/glp-lovelace-card#122.
-  'GLP-TOKENS v1':          { issue: 'mxkissnr/glp-lovelace-card#122', reason: 'type scale, spacing ladder and --glp-aline land in both cards at once' },
-  'GLP-SHARED:icons v1':    { issue: 'mxkissnr/glp-lovelace-card#122', reason: 'new shared block, absent from the neighbour default branch' },
-  'GLP-SHARED:contrast v1': { issue: 'mxkissnr/glp-lovelace-card#122', reason: '_rgbOf/_contrastOf split out for the accent-line resolution' },
-};
+const TRANSITIONAL = {};
 
 for (const [name, entry] of Object.entries(TRANSITIONAL)) {
   if (!entry || !entry.issue) {


### PR DESCRIPTION
Closes #122

Both redesign PRs have merged, so both default branches carry the same shared blocks and
the drift guard compares them again instead of skipping three of them.

Verified locally that the check is genuinely active rather than merely green: the sibling
checkout carries the matching blocks, so the comparison runs and passes on its own.