### PR TITLE
chore(release): v2.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.20.1] – 2026-08-19
 ### Changed
 - **Switched dependency updates from Dependabot to Renovate** (`renovate.json`), matching the same npm dev-dependency and codeql-action grouping as before, plus automerge for green minor/patch updates (the card has no runtime npm dependencies, only build/lint/test tooling), immediate unscheduled security PRs, weekly lockfile maintenance, and semantic commits matching the existing convention. CI/tooling only, no card behavior change. glp-lovelace-card#133
 

--- a/glp-card.js
+++ b/glp-card.js
@@ -1,4 +1,4 @@
-const GLP_CARD_VERSION = '2.20.0';
+const GLP_CARD_VERSION = '2.20.1';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
 // DE wording is the original card text; language follows hass.language (DE/EN/IT/FR/ES/NL, falls back to EN).


### PR DESCRIPTION
## Summary
- Patch release: files the Unreleased CHANGELOG entries (Renovate migration, Gitea CI-skip fix, radius/CTA color polish) under v2.20.1.
- No new user-facing capability, no README/DOCS changes needed.

## Test plan
- [x] `npm run build`
- [x] `npm test` (96/96)
- [x] `npm run lint` (0 errors, 2 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)