### PR TITLE
chore: retry-wrap the Playwright Chromium install step in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ jobs:
   test:
     name: Test and build
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -55,7 +55,20 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        # apt-get (triggered by --with-deps) has hung indefinitely before when
+        # the runner's regional Ubuntu mirror was unreachable (#138) -- a short
+        # per-attempt timeout + retry lets a single mirror hiccup self-heal
+        # within this run instead of needing a manual rerun.
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 npx playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "Playwright install attempt $attempt/3 failed or timed out, retrying..."
+            sleep 10
+          done
+          echo "::error::Playwright Chromium install failed after 3 attempts"
+          exit 1
 
       - name: Lint
         run: npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- Internal: retry-wrap the CI Playwright Chromium install step (short per-attempt timeout + 3 retries) instead of relying on the bare 8-minute job timeout, so a runner-side apt-mirror hiccup self-heals within one CI run. Job timeout raised to 20 minutes to give the retries room. CI/tooling only, no card behavior change. glp-lovelace-card#138
+
 ## [2.20.1] – 2026-08-19
 ### Changed
 - **Switched dependency updates from Dependabot to Renovate** (`renovate.json`), matching the same npm dev-dependency and codeql-action grouping as before, plus automerge for green minor/patch updates (the card has no runtime npm dependencies, only build/lint/test tooling), immediate unscheduled security PRs, weekly lockfile maintenance, and semantic commits matching the existing convention. CI/tooling only, no card behavior change. glp-lovelace-card#133


### PR DESCRIPTION
## Summary
- apt-get (triggered by `--with-deps`) hung indefinitely today when the runner's regional Ubuntu mirror was unreachable — needed 3 manual reruns to get past the bare 8-minute job timeout.
- Wraps the install step in a short per-attempt timeout + 3 retries so a single mirror hiccup self-heals within one CI run.
- Job timeout raised 8 → 20 minutes to give the retries room.

## Related issue
Closes #138

## Checklist
- [x] Issue linked above
- [x] CHANGELOG.md updated