### PR TITLE
fix: correct stale dependency-review-action version comment

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Dependency review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0


### PR DESCRIPTION
Same fix as mxkissnr/glp-integration#158 — pinned SHA is v5.0.0, comment said v4, no floating v4 tag exists upstream so Renovate's digest lookup couldn't resolve it. Typo/comment-only fix, no issue needed.