### PR TITLE
fix: wrap glp-card.js in an IIFE to avoid global-scope collision with Order Card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- **The Shot Card failed to register at all when bundled alongside the Order Card** (`glp-integration` v1.31.0+), showing "Custom element doesn't exist: glp-card" in the card picker. Both cards are loaded as classic `<script src>` tags in the same HA frontend document and declared identical top-level `const` names (`STRINGS`, `THEME_PRESETS`, `MACHINE_BODY`, `MACHINE_ICON_MINI`, `GLP_ICON_PATHS`, `ICONS`, `STYLES`) — classic scripts share that lexical scope, so whichever card's script loaded second threw `SyntaxError: Identifier already declared` and aborted before `customElements.define()` ran. `glp-card.js` is now wrapped in an IIFE so its top-level declarations no longer leak into the shared document scope; same fix applied in glp-order-card. #141
+
 ### Changed
 - Internal: retry-wrap the CI Playwright Chromium install step (short per-attempt timeout + 3 retries) instead of relying on the bare 8-minute job timeout, so a runner-side apt-mirror hiccup self-heals within one CI run. Job timeout raised to 20 minutes to give the retries room. CI/tooling only, no card behavior change. glp-lovelace-card#138
 

--- a/glp-card.js
+++ b/glp-card.js
@@ -1,3 +1,11 @@
+// Wrapped in an IIFE so top-level `const`/`class` declarations don't leak into
+// the shared document-global scope: this card ships bundled alongside
+// glp-order-card.js as a second classic <script src> in the same HA frontend
+// page (glp-integration#157), and classic scripts share that lexical scope —
+// a same-named top-level const in both files throws on the second load and
+// aborts before customElements.define() runs. #141
+(() => {
+
 const GLP_CARD_VERSION = '2.20.1';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
@@ -2767,3 +2775,5 @@ console.info(
   'background:#ff3b30;color:#fff;padding:2px 4px;border-radius:3px 0 0 3px',
   'background:#111113;color:#ff3b30;padding:2px 4px;border-radius:0 3px 3px 0'
 );
+
+})();

--- a/test/curve-animation.test.js
+++ b/test/curve-animation.test.js
@@ -15,7 +15,7 @@ function loadCard() {
   let src = fs.readFileSync(path.join(__dirname, '..', 'glp-card.js'), 'utf8');
   src = src.replace(
     "customElements.define('glp-card', GlpCard);",
-    "customElements.define('glp-card', GlpCard); globalThis.__GlpCard = GlpCard;"
+    "customElements.define('glp-card', GlpCard); globalThis.__GlpCard = GlpCard; globalThis.metricLineHtml = metricLineHtml;"
   );
 
   class HTMLElement {}

--- a/test/security-helpers.test.js
+++ b/test/security-helpers.test.js
@@ -13,7 +13,15 @@ const path = require('node:path');
 const vm = require('node:vm');
 
 function loadCardHelpers() {
-  const src = fs.readFileSync(path.join(__dirname, '..', 'glp-card.js'), 'utf8');
+  let src = fs.readFileSync(path.join(__dirname, '..', 'glp-card.js'), 'utf8');
+  // #141: glp-card.js is wrapped in an IIFE to avoid a top-level const
+  // collision with the bundled glp-order-card.js, so esc()/safeUrl() no
+  // longer auto-attach to the vm context's global object — expose them
+  // explicitly for this test, same injection approach as __GlpCard below.
+  src = src.replace(
+    "customElements.define('glp-card', GlpCard);",
+    "customElements.define('glp-card', GlpCard); globalThis.esc = esc; globalThis.safeUrl = safeUrl;"
+  );
 
   class HTMLElement {}
 
@@ -24,6 +32,7 @@ function loadCardHelpers() {
     console,
     URL,
   };
+  context.globalThis = context;
   vm.createContext(context);
   vm.runInContext(src, context, { filename: path.join(__dirname, '..', 'glp-card.js') });
 


### PR DESCRIPTION
## Summary
- `glp-card.js` and `glp-order-card.js` are both loaded as classic `<script src>` tags in the same HA frontend document when `glp-integration` bundles both cards (v1.31.0+). Classic scripts share the global lexical scope, and both files declare identical top-level `const` names (`STRINGS`, `THEME_PRESETS`, `MACHINE_BODY`, `MACHINE_ICON_MINI`, `GLP_ICON_PATHS`, `ICONS`, `STYLES`) — whichever loads second throws `SyntaxError: Identifier already declared` and aborts before `customElements.define('glp-card', ...)` runs.
- Wraps the entire file in an IIFE so its top-level declarations stay scoped, eliminating this whole class of collision (not just today's 7 names).
- Companion fix in glp-order-card: mxkissnr/glp-order-card#114.
- Two vm-based test harnesses (`security-helpers.test.js`, `curve-animation.test.js`) relied on `esc`/`safeUrl`/`metricLineHtml` auto-attaching to the vm context's global object as bare top-level function declarations — no longer true inside the IIFE. Extended the existing source-string-injection pattern (already used for `__GlpCard`) to expose them explicitly for tests only; production behavior of the shipped file is unaffected.

Closes #141

## Test plan
- [x] `npm run build` (syntax check)
- [x] `npm test` — 96/96 passing, including the byte-identical shared-block cross-checks against glp-order-card.js
- [x] `npm run lint` — 0 errors (2 pre-existing innerHTML warnings, unrelated)