### PR TITLE
Release v2.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [2.20.2] – 2026-08-20
 ### Fixed
 - **The Shot Card failed to register at all when bundled alongside the Order Card** (`glp-integration` v1.31.0+), showing "Custom element doesn't exist: glp-card" in the card picker. Both cards are loaded as classic `<script src>` tags in the same HA frontend document and declared identical top-level `const` names (`STRINGS`, `THEME_PRESETS`, `MACHINE_BODY`, `MACHINE_ICON_MINI`, `GLP_ICON_PATHS`, `ICONS`, `STYLES`) — classic scripts share that lexical scope, so whichever card's script loaded second threw `SyntaxError: Identifier already declared` and aborted before `customElements.define()` ran. `glp-card.js` is now wrapped in an IIFE so its top-level declarations no longer leak into the shared document scope; same fix applied in glp-order-card. #141
 

--- a/glp-card.js
+++ b/glp-card.js
@@ -6,7 +6,7 @@
 // aborts before customElements.define() runs. #141
 (() => {
 
-const GLP_CARD_VERSION = '2.20.1';
+const GLP_CARD_VERSION = '2.20.2';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
 // DE wording is the original card text; language follows hass.language (DE/EN/IT/FR/ES/NL, falls back to EN).


### PR DESCRIPTION
## Summary
- Version bump 2.20.1 → 2.20.2 (patch: bugfix-only)
- CHANGELOG.md `[Unreleased]` retitled to `[2.20.2] – 2026-08-20`

## Test plan
- [x] `npm test` (96/96 passing)
- [x] `npm run build` (syntax check)