### PR TITLE
docs: add CHANGELOG entry for codeql-action digest bump (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- **Bumped the `github/codeql-action` digest pin to `db488dd`** (Renovate, #152). CI/tooling only, no card behavior change.
 
 ## [2.20.3] – 2026-08-22
 ### Fixed


### PR DESCRIPTION
Adds a CHANGELOG entry for the already-merged Renovate PR #152 (codeql-action digest bump), matching the existing entry style for dependency bumps.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>