### PR TITLE
Add watchdog timer against a permanently stuck touch guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- **The card could freeze permanently on Android if a touch guard flag never cleared.** `_touchActive` (added for #147) is only reset by `touchend`/`touchcancel`; if the WebView failed to deliver either for some finger (ghost/interrupted touch), the card was blocked from re-rendering for the rest of the session — matching reports of the card sometimes not showing up at all. `_bindTouchGuard()` now also starts a short safety-net timer on `touchstart` that force-clears `_touchActive` (and flushes any pending render) if no matching end event arrives; a real `touchend`/`touchcancel` cancels it as usual. `glp-card.js`, `test/render-guard.test.js`. Closes #155
+
 ### Changed
 - **Bumped the `github/codeql-action` digest pin to `db488dd`** (Renovate, #152). CI/tooling only, no card behavior change.
 

--- a/glp-card.js
+++ b/glp-card.js
@@ -1467,6 +1467,13 @@ class GlpCard extends HTMLElement {
     // #147: true while the user's finger is in contact with the card
     // (touchstart..touchend/touchcancel) — see _bindTouchGuard().
     this._touchActive   = false;
+    // #155: safety-net timer that force-clears _touchActive if the
+    // WebView never delivers a matching touchend/touchcancel (Android
+    // ghost-touch cases) — see _bindTouchGuard(). Exposed as an instance
+    // field (not a hardcoded literal in _bindTouchGuard()) so tests can
+    // shrink it instead of depending on mocked global timers.
+    this._touchGuardTimer = null;
+    this._touchGuardTimeoutMs = 1000;
     // set when a render was requested while _renderBlocked() (#72) — replayed
     // once by _requestRender() as soon as the blocking interaction ends,
     // instead of being discarded like it was before.
@@ -1566,7 +1573,21 @@ class GlpCard extends HTMLElement {
   // preventDefault(), or the very native scroll this guard exists to protect
   // would itself be blocked.
   _bindTouchGuard() {
-    this.addEventListener('touchstart', () => { this._touchActive = true; }, { passive: true });
+    // #155: some Android WebViews occasionally fail to deliver a matching
+    // touchend/touchcancel for a touch (ghost/interrupted gesture) — without
+    // a safety net, _touchActive would then stay true forever, permanently
+    // blocking _renderBlocked() and freezing the card for the rest of the
+    // session. This timer force-clears it if no real end event shows up.
+    const clearTouchActive = () => {
+      this._touchActive = false;
+      this._touchGuardTimer = null;
+      if (this._pendingRender) this._requestRender();
+    };
+    this.addEventListener('touchstart', () => {
+      this._touchActive = true;
+      clearTimeout(this._touchGuardTimer);
+      this._touchGuardTimer = setTimeout(clearTouchActive, this._touchGuardTimeoutMs);
+    }, { passive: true });
     // touchend/touchcancel fire once per finger lifted, not once all fingers
     // are gone (Touch Events spec) — a second finger resting on the card
     // (accidental edge touch, or a pinch/zoom starting on the card) must keep
@@ -1575,8 +1596,8 @@ class GlpCard extends HTMLElement {
     // mid-gesture rebuild #147 exists to prevent.
     const onTouchEnd = e => {
       if (e.touches.length > 0) return;
-      this._touchActive = false;
-      if (this._pendingRender) this._requestRender();
+      clearTimeout(this._touchGuardTimer);
+      clearTouchActive();
     };
     this.addEventListener('touchend', onTouchEnd, { passive: true });
     this.addEventListener('touchcancel', onTouchEnd, { passive: true });

--- a/test/render-guard.test.js
+++ b/test/render-guard.test.js
@@ -42,6 +42,8 @@ function makeInstance() {
   inst._maintConfirm = null;
   inst._readyByInteracting = false;
   inst._touchActive = false;
+  inst._touchGuardTimer = null;
+  inst._touchGuardTimeoutMs = 1000;
   inst._pendingRender = false;
   return inst;
 }
@@ -256,6 +258,44 @@ test('_bindTouchGuard(): a second finger on the card keeps the guard held until 
   assert.equal(inst._touchActive, false);
   assert.equal(renderCount(), 1, 'the deferred render must be replayed exactly once once all fingers are gone');
   assert.equal(inst._pendingRender, false);
+});
+
+// #155: Android WebView can occasionally fail to deliver a matching
+// touchend/touchcancel (ghost/interrupted touch). Without a safety net,
+// _touchActive would stay true forever, permanently blocking every future
+// render — matching the reported "card sometimes isn't shown at all".
+test('_bindTouchGuard(): a watchdog timer force-clears _touchActive if touchend never arrives', async () => {
+  const inst = makeInstance();
+  inst._touchGuardTimeoutMs = 10; // real, short timer instead of mocking globals inside the vm sandbox
+  const renderCount = spyOnRender(inst);
+  const listeners = bindFakeTouchGuard(inst);
+
+  listeners.touchstart();
+  inst._requestRender();
+  assert.equal(renderCount(), 0);
+  assert.equal(inst._pendingRender, true);
+
+  // No touchend/touchcancel ever arrives -- simulate a lost event.
+  await new Promise(resolve => setTimeout(resolve, 30));
+
+  assert.equal(inst._touchActive, false, 'watchdog must clear the stuck guard flag');
+  assert.equal(renderCount(), 1, 'the deferred render must be flushed once the watchdog fires');
+});
+
+test('_bindTouchGuard(): a real touchend cancels the watchdog timer (no double-clear/double-render)', async () => {
+  const inst = makeInstance();
+  inst._touchGuardTimeoutMs = 10;
+  const renderCount = spyOnRender(inst);
+  const listeners = bindFakeTouchGuard(inst);
+
+  listeners.touchstart();
+  listeners.touchend({ touches: [] });
+  assert.equal(inst._touchActive, false);
+
+  // Advancing past the watchdog window must not fire a second, stale
+  // clear/render now that the real touchend already handled it.
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(renderCount(), 0, 'no render was ever pending, so nothing should have fired');
 });
 
 test('set hass() pushes during an active touch do not rebuild the DOM, and touchend catches up with the latest hass state', () => {


### PR DESCRIPTION
## Summary
- `_touchActive` (added for #147) is only cleared by `touchend`/`touchcancel`. If Android's WebView fails to deliver either for some finger (ghost/interrupted touch), the flag never clears, permanently blocking `_renderBlocked()` and freezing the card for the rest of the session — matching reports of the card sometimes not rendering at all.
- `_bindTouchGuard()` now also starts a short safety-net timer on `touchstart` that force-clears `_touchActive` (and flushes any pending render) if no matching end event arrives; a real `touchend`/`touchcancel` cancels it as usual.

Closes #155

## Test plan
- [x] New tests in `test/render-guard.test.js`: watchdog fires and flushes a pending render when no touchend ever arrives; a real touchend cancels the watchdog (no double render)
- [x] `npm test` — 104 passed
- [x] `npm run build` — clean
- [x] `npx eslint glp-card.js` — no new warnings