### PR TITLE
Release v2.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [2.20.4] – 2026-08-25
 ### Fixed
 - **The card could freeze permanently on Android if a touch guard flag never cleared.** `_touchActive` (added for #147) is only reset by `touchend`/`touchcancel`; if the WebView failed to deliver either for some finger (ghost/interrupted touch), the card was blocked from re-rendering for the rest of the session — matching reports of the card sometimes not showing up at all. `_bindTouchGuard()` now also starts a short safety-net timer on `touchstart` that force-clears `_touchActive` (and flushes any pending render) if no matching end event arrives; a real `touchend`/`touchcancel` cancels it as usual. `glp-card.js`, `test/render-guard.test.js`. Closes #155
 

--- a/glp-card.js
+++ b/glp-card.js
@@ -6,7 +6,7 @@
 // aborts before customElements.define() runs. #141
 (() => {
 
-const GLP_CARD_VERSION = '2.20.3';
+const GLP_CARD_VERSION = '2.20.4';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
 // DE wording is the original card text; language follows hass.language (DE/EN/IT/FR/ES/NL, falls back to EN).


### PR DESCRIPTION
## Summary
- Bump GLP_CARD_VERSION to 2.20.4
- Finalize CHANGELOG.md: retitle Unreleased -> 2.20.4 (2026-08-25)

Pure bugfix release (PR #156, closes #155): watchdog timer against a permanently stuck touch guard flag.

## Test plan
- [x] npm test (104 passed)
- [x] npm run build

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>