### PR TITLE
Fix: derive uptime badge from restart-safe preheat_elapsed, not switch.last_changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [2.20.5] – 2026-08-26
+### Fixed
+- **The "machine on since" uptime badge reset to 0:00 on every Home Assistant restart, even though the machine stayed physically on.** It derived `_machineOnSince` from `switch.*.last_changed`; a HA core restart rebuilds the state machine, so the switch's `last_changed` jumps to the restart/reconnect time instead of keeping the real original power-on timestamp. The preheat progress bar was unaffected — it already reads `preheat_elapsed`/`preheat_remaining`, which the add-on persists to disk and re-serves correctly across restarts. `_machineOnSince` is now derived from that same restart-safe `preheat_elapsed` sensor instead. `glp-card.js`. Closes #158
+
 ## [2.20.4] – 2026-08-25
 ### Fixed
 - **The card could freeze permanently on Android if a touch guard flag never cleared.** `_touchActive` (added for #147) is only reset by `touchend`/`touchcancel`; if the WebView failed to deliver either for some finger (ghost/interrupted touch), the card was blocked from re-rendering for the rest of the session — matching reports of the card sometimes not showing up at all. `_bindTouchGuard()` now also starts a short safety-net timer on `touchstart` that force-clears `_touchActive` (and flushes any pending render) if no matching end event arrives; a real `touchend`/`touchcancel` cancels it as usual. `glp-card.js`, `test/render-guard.test.js`. Closes #155

--- a/glp-card.js
+++ b/glp-card.js
@@ -6,7 +6,7 @@
 // aborts before customElements.define() runs. #141
 (() => {
 
-const GLP_CARD_VERSION = '2.20.4';
+const GLP_CARD_VERSION = '2.20.5';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
 // DE wording is the original card text; language follows hass.language (DE/EN/IT/FR/ES/NL, falls back to EN).
@@ -2432,8 +2432,12 @@ class GlpCard extends HTMLElement {
       localStorage.setItem(this._switchStorageKey(), resolvedSwitch);
     }
     const switchState = this._switchEntity ? this._hass.states[this._switchEntity] : null;
-    this._machineOnSince = (switchState?.state === 'on' && switchState.last_changed)
-      ? Date.parse(switchState.last_changed) : null;
+    // Derived from preheat_elapsed (restart-safe, persisted by the add-on),
+    // not switch.*.last_changed — that jumps to restart time on every HA
+    // core restart even while the machine stays physically on (#158).
+    const uptimePreheatEl = parseFloat(this._val('preheat_elapsed', null));
+    this._machineOnSince = (switchState?.state === 'on' && !isNaN(uptimePreheatEl))
+      ? Date.now() - uptimePreheatEl * 1000 : null;
     const machineOff  = !!(this._switchEntity &&
       (switchState?.state === 'off' || switchState?.state === 'unavailable'));
 
@@ -2556,7 +2560,7 @@ class GlpCard extends HTMLElement {
     const preheatReady   = this._hass.states[bsPrefix + 'preheat_ready']?.state === 'on';
     const preheatHasEnt  = !!this._hass.states[bsPrefix + 'preheat_ready'];
     const preheatRem     = parseFloat(this._val('preheat_remaining', null));
-    const preheatEl      = parseFloat(this._val('preheat_elapsed',   null));
+    const preheatEl      = uptimePreheatEl;
     const preheatTotal   = (!isNaN(preheatRem) && !isNaN(preheatEl)) ? preheatEl + preheatRem : null;
     const preheatPct     = preheatTotal ? Math.min(1, preheatEl / preheatTotal) : null;
     const preheatMinLeft = isNaN(preheatRem) ? null : Math.ceil(preheatRem / 60);


### PR DESCRIPTION
switch.*.last_changed jumps to restart/reconnect time on every HA core
restart even while the machine stays physically on, resetting the
"machine on since" badge to 0:00. preheat_elapsed is already persisted
by the add-on and survives restarts correctly, so use it as the source
instead.

Closes #158