### PR TITLE
chore: raise coverage threshold to match measured baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Chore
+- **Raised the coverage threshold from 53% to 59%** to match the real measured 61.27% baseline instead of a stale, wider-than-necessary floor. Closes #165
 
 ## [2.20.5] – 2026-08-26
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "test": "node --test",
-    "test:coverage": "c8 --reporter=text --reporter=json-summary --check-coverage --lines=53 node --test",
+    "test:coverage": "c8 --reporter=text --reporter=json-summary --check-coverage --lines=59 node --test",
     "build": "node --check glp-card.js",
     "lint": "eslint .",
     "screenshot": "node scripts/screenshot.mjs",


### PR DESCRIPTION
Follow-up to the 2026-08-31 ecosystem audit (see `glp-project/AUDIT-2026-08-31.md` in a sibling repo).

Closes #165 — coverage gate was 53%, real measured coverage is 61.27%.

Tests + build green.