### PR TITLE
docs+ci: PR guidelines + mandatory AI assistance disclosure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,16 @@ Closes #
 - [ ] `CHANGELOG.md` updated
 - [ ] `GLP_CARD_VERSION` bumped in `glp-card.js`
 - [ ] `README.md` updated (if new feature)
+
+## AI assistance disclosure
+
+<!-- Required. Tick exactly ONE level and fill in the tools/models line. -->
+<!-- The durable record is the `Co-Authored-By:` trailer on each AI-assisted commit;
+     this section is the human-readable summary for reviewers. -->
+
+- [ ] **none** — no AI tool involved
+- [ ] **assisted** — AI autocomplete or review suggestions only; code written by a human
+- [ ] **substantial** — AI generated significant portions; human reviewed and revised
+- [ ] **generated** — code is AI-generated end-to-end; human reviewed and takes responsibility
+
+Tools / models used: <!-- e.g. "Claude Code (Sonnet 5)", "GitHub Copilot", "none" -->

--- a/.github/workflows/pr-ai-disclosure.yaml
+++ b/.github/workflows/pr-ai-disclosure.yaml
@@ -1,0 +1,53 @@
+name: PR AI disclosure
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: AI assistance disclosure present
+    runs-on: ubuntu-latest
+    # Skip bot dependency PRs (renovate/dependabot) — no AI authoring involved.
+    if: >
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate disclosure
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          body_file="$(mktemp)"; printf '%s' "$PR_BODY" > "$body_file"
+
+          levels=$(grep -cE '^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*\*\*(none|assisted|substantial|generated)\*\*' "$body_file" || true)
+          if [ "$levels" -ne 1 ]; then
+            echo "::error::Tick exactly one AI assistance level (none/assisted/substantial/generated). Found: $levels"
+            exit 1
+          fi
+
+          if ! grep -qE '^[[:space:]]*Tools[[:space:]]*/[[:space:]]*models used:[[:space:]]*\S' "$body_file"; then
+            echo "::error::Fill in the 'Tools / models used:' line in the AI assistance disclosure section."
+            exit 1
+          fi
+
+          if grep -qE '^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*\*\*none\*\*' "$body_file"; then
+            if git log --format='%B' "${BASE_SHA}..${HEAD_SHA}" \
+                 | grep -qiE 'Co-Authored-By:.*(Claude|Copilot|Cursor|Codeium|Windsurf|Devin|Gemini|ChatGPT|GPT-|noreply@anthropic)'; then
+              echo "::error::Commits carry an AI Co-Authored-By trailer, but the PR discloses 'none'."
+              exit 1
+            fi
+          fi
+
+          echo "AI assistance disclosure OK."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,5 +15,8 @@ Working rules for this repo (mirrors the app repo's rules; full rationale lives 
   model spelled out: `Co-Authored-By: Claude <model name> <noreply@anthropic.com>`.
 - **XSS**: card renders HA data into DOM — always escape/textContent, never
   unsanitized innerHTML from entity attributes.
+- **PR AI disclosure** — every PR fills the PR template's "AI assistance disclosure" section
+  (`none`/`assisted`/`substantial`/`generated` + tool/model); every AI-assisted commit carries
+  a `Co-Authored-By:` trailer. CI enforces it. See CONTRIBUTING.md.
 - **Releases** end at the GitHub release + HACS; no HA deploy (Max installs himself).
 - Screenshots: `npm run screenshot` regenerates docs assets when the UI changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,36 @@ Bug reports, feature ideas and pull requests are welcome!
 1. **Open an issue first** — describe the bug or feature before writing any code
 2. **Fork & branch** — `feature/short-description` or `fix/short-description`
 3. **Implement** — commit with `Closes #N` in the message
-4. **Pull request** — reference the issue; keep PRs focused on one thing
+4. **Pull request** — see [Pull requests](#pull-requests) below
+
+## Pull requests
+
+Every PR must:
+
+- **Link an issue** — `Closes #N` in the description (no PRs without a linked issue)
+- **Do one thing** — keep the diff focused; split unrelated changes
+- **Use a Conventional Commits title in English** — `feat:` `fix:` `docs:` `chore:` `refactor:` `test:` `build:`
+- **Explain what and why** in the description, not just what
+- **Pass CI** — lint, tests and build green before requesting review
+- **Update `CHANGELOG.md`** for any user-facing change
+- **Include before/after screenshots** for UI changes
+- **Disclose AI assistance** — see below
+- **No real names** in commit messages, PR text, code comments or docs
+
+### AI assistance
+
+Be transparent about AI tool use so reviewers know what they are reviewing.
+
+- **Per commit (machine-readable, required):** every commit an AI tool helped write carries a
+  trailer, e.g. `Co-Authored-By: Claude <noreply@anthropic.com>` or
+  `Co-Authored-By: Copilot <198982749+Copilot@users.noreply.github.com>`. Claude Code also
+  adds a `Claude-Session:` trailer. For this repo the Claude trailer names the specific model,
+  e.g. `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>` (see [CLAUDE.md](CLAUDE.md)).
+- **Per PR (summary, required):** the "AI assistance disclosure" section of the PR template —
+  one of `none` / `assisted` / `substantial` / `generated`, plus the tool and model names.
+
+CI blocks the PR until the disclosure section is filled in, and fails on a contradiction
+(commits carry an AI trailer while the PR claims `none`).
 
 ## Reporting a bug
 


### PR DESCRIPTION
## Summary

Introduces a consistent PR policy for the repo:

- **PR template** (`.github/pull_request_template.md`) — new required "AI assistance disclosure" section (`none` / `assisted` / `substantial` / `generated` + a "Tools / models used:" line), placed after the existing checklist.
- **`CONTRIBUTING.md`** — new "Pull requests" section (link an issue, do one thing, Conventional Commits title in English, explain what & why, pass CI, update CHANGELOG, screenshots for UI changes, disclose AI assistance, no real names) with an "AI assistance" subsection describing the per-commit `Co-Authored-By:` trailer and the per-PR disclosure. The now-redundant "Pull request" line in the existing "Workflow" section is folded into a pointer.
- **`.github/workflows/pr-ai-disclosure.yaml`** — new blocking CI check. Fails unless exactly one disclosure level is ticked and the "Tools / models used:" line is filled, and fails on a contradiction (commits carry an AI `Co-Authored-By:` trailer while the PR discloses `none`). Skips renovate/dependabot PRs and anything labelled `dependencies`. `actions/checkout` is pinned to `3d3c42e5aac5ba805825da76410c181273ba90b1` (v7), the same SHA the other workflows use.
- **`CLAUDE.md`** — one convention line pointing at the policy.

Identical rollout is tracked in the sibling repos (gaggiuino-local-profiler, glp-order-card, glp-ha).

## Related issue

Closes #167

## Checklist

- [x] Issue linked above
- [ ] `CHANGELOG.md` updated — n/a, tooling/process change only
- [ ] `GLP_CARD_VERSION` bumped in `glp-card.js` — n/a
- [ ] `README.md` updated (if new feature) — n/a

## AI assistance disclosure

<!-- Required. Tick exactly ONE level and fill in the tools/models line. -->
<!-- The durable record is the `Co-Authored-By:` trailer on each AI-assisted commit;
     this section is the human-readable summary for reviewers. -->

- [ ] **none** — no AI tool involved
- [ ] **assisted** — AI autocomplete or review suggestions only; code written by a human
- [ ] **substantial** — AI generated significant portions; human reviewed and revised
- [x] **generated** — code is AI-generated end-to-end; human reviewed and takes responsibility

Tools / models used: Claude Code (Sonnet 5)

## Note for branch protection

If this repo has a required-status-checks list, add **"AI assistance disclosure present"** to it so the new check actually blocks merges (settings change, not doable from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
