### PR TITLE
feat: add descaling banner with animation to Live tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- **Live tab now shows a descaling banner while the machine is running its descale program**, matching the existing brewing/steam banners. Reads the new `is_descaling` attribute on the `Brewing` binary sensor (`glp-integration#186`), always exposed regardless of the brew (`is_on`) state itself, so the banner shows up even when no shot is running. New `.descaling-banner` (own droplet+mineral-crystal icon, `--accent` color family matching this card's existing "due maintenance" tokens, slow icon-pulse animation distinct from the static brewing/steam banners) plus `descaling_mode` translation keys in all 6 languages. `glp-card.js`, `test/e2e/smoke.test.mjs`. Closes #170
+
 ### Chore
 - **Raised the coverage threshold from 53% to 59%** to match the real measured 61.27% baseline instead of a stale, wider-than-necessary floor. Closes #165
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Per-machine colour theme (`theme`/`accent_color`/`accent_gradient`) syncs automa
 - **Profile selector** — custom pill-button picker (no native `<select>`) to switch the active brew profile; stays open across HA state updates; auto-detected via entity prefix; requires `select.*_profile` from [GLP Integration](https://github.com/mxkissnr/glp-integration) v1.9.0+; hidden when unavailable
 - **Maintenance tab** — tab bar (☕ Shot | 🔧 Wartung) appears automatically when GLP maintenance sensors exist; shows all five machine maintenance tasks plus per-grinder cleaning schedules with status pill, days/shots since last service and a colored progress bar; ⚠ on the tab label when anything is due; **tap a task to mark it done** (with a confirmation step) via the `gaggiuino_profiler.maintenance_done` service — requires [GLP Integration](https://github.com/mxkissnr/glp-integration) v1.11.0+
 - **Steam mode banner** — shown automatically when steam switch is active
+- **Descaling banner** — shown automatically while the machine is running its descale program, with its own icon and pulse animation; reads the `is_descaling` attribute on the Brewing binary sensor, requires [GLP Integration](https://github.com/mxkissnr/glp-integration) v1.32.0+
 - **Water level** in footer (💧 XX%); warning banner when below 20%
 - Last shot: profile name, coffee bean, rating (★), duration, yield, brew ratio, avg pressure, temp, target temp
 - **Bean info enrichment** — origin flag, variety and roast age next to the bean name, fetched from the coffee library via the integration proxy (`GET /api/glp/library/beans-info`; requires [GLP Integration](https://github.com/mxkissnr/glp-integration) v1.16.0+ and GLP app v1.96.0+; hidden automatically on older installations)
@@ -106,7 +107,7 @@ The card reads the following entities (with default `entity_prefix`):
 
 | Entity | Description |
 |---|---|
-| `binary_sensor.gaggiuino_local_profiler_brewing` | Live brewing state; attributes: `datapoints`, `profile_name`, `seq` during active shot (v1.9.4+) |
+| `binary_sensor.gaggiuino_local_profiler_brewing` | Live brewing state; attributes: `datapoints`, `profile_name`, `seq` during active shot (v1.9.4+); `is_descaling` always present, drives the descaling banner (v1.32.0+) |
 | `binary_sensor.gaggiuino_local_profiler_preheat_ready` | Machine warmed up |
 | `binary_sensor.gaggiuino_local_profiler_steam_switch` | Steam mode active *(optional)* |
 | `sensor.gaggiuino_local_profiler_preheat_elapsed` | Warmup elapsed (s) |

--- a/glp-card.js
+++ b/glp-card.js
@@ -6,7 +6,7 @@
 // aborts before customElements.define() runs. #141
 (() => {
 
-const GLP_CARD_VERSION = '2.20.5';
+const GLP_CARD_VERSION = '2.21.0';
 
 // ─── i18n ────────────────────────────────────────────────────────────────────
 // DE wording is the original card text; language follows hass.language (DE/EN/IT/FR/ES/NL, falls back to EN).
@@ -28,6 +28,7 @@ const STRINGS = {
     profile_label: 'Profil', profile_switching: 'wechselt …',
     lm_live: 'Maschine live',
     steam_mode: 'Dampfmodus', water_low: p => `Wasser fast leer (${p}%)`,
+    descaling_mode: 'Entkalkung läuft',
     preheat_ready: 'Brühbereit', preheat_heating: 'Aufheizen …',
     ready_by_set_label: 'Brühbereit bis', ready_by_set: 'Setzen',
     ready_by_target: hhmm => `Brühbereit bis ${hhmm}`, ready_by_cancel: 'Abbrechen',
@@ -58,6 +59,7 @@ const STRINGS = {
     profile_label: 'Profile', profile_switching: 'switching …',
     lm_live: 'Machine live',
     steam_mode: 'Steam mode', water_low: p => `Water almost empty (${p}%)`,
+    descaling_mode: 'Descaling',
     preheat_ready: 'Ready to brew', preheat_heating: 'Warming up …',
     ready_by_set_label: 'Ready by', ready_by_set: 'Set',
     ready_by_target: hhmm => `Ready by ${hhmm}`, ready_by_cancel: 'Cancel',
@@ -88,6 +90,7 @@ const STRINGS = {
     profile_label: 'Profilo', profile_switching: 'cambio in corso …',
     lm_live: 'Macchina in diretta',
     steam_mode: 'Modalità vapore', water_low: p => `Acqua quasi esaurita (${p}%)`,
+    descaling_mode: 'Decalcificazione in corso',
     preheat_ready: 'Pronto per l\'estrazione', preheat_heating: 'Riscaldamento …',
     ready_by_set_label: 'Pronto entro', ready_by_set: 'Imposta',
     ready_by_target: hhmm => `Pronto entro le ${hhmm}`, ready_by_cancel: 'Annulla',
@@ -118,6 +121,7 @@ const STRINGS = {
     profile_label: 'Profil', profile_switching: 'changement …',
     lm_live: 'Machine en direct',
     steam_mode: 'Mode vapeur', water_low: p => `Eau presque vide (${p}%)`,
+    descaling_mode: 'Détartrage en cours',
     preheat_ready: 'Prêt à infuser', preheat_heating: 'Chauffage …',
     ready_by_set_label: 'Prêt avant', ready_by_set: 'Définir',
     ready_by_target: hhmm => `Prêt avant ${hhmm}`, ready_by_cancel: 'Annuler',
@@ -148,6 +152,7 @@ const STRINGS = {
     profile_label: 'Perfil', profile_switching: 'cambiando …',
     lm_live: 'Máquina en directo',
     steam_mode: 'Modo vapor', water_low: p => `Agua casi vacía (${p}%)`,
+    descaling_mode: 'Descalcificación en curso',
     preheat_ready: 'Listo para extraer', preheat_heating: 'Calentando …',
     ready_by_set_label: 'Listo antes de', ready_by_set: 'Fijar',
     ready_by_target: hhmm => `Listo antes de las ${hhmm}`, ready_by_cancel: 'Cancelar',
@@ -178,6 +183,7 @@ const STRINGS = {
     profile_label: 'Profiel', profile_switching: 'wisselt …',
     lm_live: 'Machine live',
     steam_mode: 'Stoommodus', water_low: p => `Water bijna leeg (${p}%)`,
+    descaling_mode: 'Ontkalken',
     preheat_ready: 'Klaar om te zetten', preheat_heating: 'Opwarmen …',
     ready_by_set_label: 'Klaar voor', ready_by_set: 'Instellen',
     ready_by_target: hhmm => `Klaar voor ${hhmm}`, ready_by_cancel: 'Annuleren',
@@ -479,6 +485,14 @@ const ICONS = {
     : ''),
 };
 // /GLP-SHARED:icons v1
+
+// #170: card-local addition, deliberately outside the GLP-SHARED:icons block
+// above (kept byte-identical with glp-order-card.js, see test/token-sync.test.js)
+// -- glp-order-card has no live-brewing view and no use for a descaling icon.
+// Same droplet silhouette as `droplet` (water) with a jagged crystalline line
+// through it, standing in for the mineral/scale deposit being flushed out --
+// visually distinct from the plain droplet used for the water-level banner.
+GLP_ICON_PATHS.descale = '<path d="M12 3s6 6.5 6 11a6 6 0 0 1-12 0c0-4.5 6-11 6-11z"/><path d="M8.3 13.6l1.5 1.7 1.4-2.3 1.5 1.7 1.5-2.3"/>';
 
 function _scale(arr) { return (Array.isArray(arr) && arr.length) ? arr.map(v => v / 10) : []; }
 
@@ -1267,13 +1281,26 @@ const STYLES = `
     font-size: var(--glp-fs-2); font-weight: 600; color: var(--amber);
     text-align: center; margin-bottom: var(--glp-sp-3);
   }
+  /* Same --accent family as .brewing-banner and .maint-pill.due (#170) --
+     descaling is a due-maintenance operation in this design system's own
+     color language, not a brand-new hue. Differentiated from the static
+     brewing/steam banners by a slow icon pulse instead: an ongoing
+     maintenance process reads as "in progress", not just "on". */
+  .descaling-banner {
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border-radius: var(--glp-radius-sm); padding: var(--glp-sp-3) var(--glp-sp-4);
+    font-size: var(--glp-fs-2); font-weight: 700; color: var(--accent);
+    text-align: center; margin-bottom: var(--glp-sp-3);
+  }
+  .descaling-banner svg { animation: descale-pulse 1.6s ease-in-out infinite; }
+  @keyframes descale-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .35; } }
   .water-low {
     background: color-mix(in srgb, var(--accent) 7%, transparent);
     border-radius: var(--glp-radius-sm); padding: 7px var(--glp-sp-4);
     font-size: var(--glp-fs-1); font-weight: 600; color: var(--accent);
     text-align: center; margin-bottom: var(--glp-sp-3);
   }
-  .brewing-banner svg, .steam-banner svg, .water-low svg, .preheat-ready svg {
+  .brewing-banner svg, .steam-banner svg, .descaling-banner svg, .water-low svg, .preheat-ready svg {
     width: 13px; height: 13px; vertical-align: -2px;
   }
 
@@ -2511,6 +2538,11 @@ class GlpCard extends HTMLElement {
     const brewing        = brewingEnt?.state === 'on';
     const liveDatapoints = brewingEnt?.attributes?.datapoints || null;
     const liveProfile    = brewingEnt?.attributes?.profile_name || null;
+    // #170: is_descaling is a separate live-session flag on the Brewing
+    // binary sensor (glp-integration#186), always exposed regardless of
+    // is_on/isLive -- same shape as is_flushing, added by the same PR but
+    // not surfaced in the card yet (out of scope for #170).
+    const isDescaling    = !!brewingEnt?.attributes?.is_descaling;
     const steamOn        = this._hass.states[bsPrefix + 'steam_switch']?.state === 'on';
     const tArr           = liveDatapoints?.timeInShot;
     const elapsedSec     = tArr?.length ? Math.round(tArr[tArr.length - 1] / 10) : null;
@@ -2809,6 +2841,7 @@ class GlpCard extends HTMLElement {
         </div>
 
         ${tabBarHtml}
+        ${isDescaling && !brewing ? `<div class="descaling-banner">${ICONS.of('descale')} ${T('descaling_mode')}</div>` : ''}
         ${steamOn && !brewing ? `<div class="steam-banner">${ICONS.of('steam')} ${T('steam_mode')}</div>` : ''}
         ${waterLevel !== null && waterLevel < 20 ? `<div class="water-low">${ICONS.of('droplet')} ${T('water_low', waterLevel)}</div>` : ''}
         ${preheatHtml}

--- a/test/e2e/smoke.test.mjs
+++ b/test/e2e/smoke.test.mjs
@@ -24,7 +24,7 @@ import { startServer } from '../../scripts/e2e-harness.mjs';
 
 const PREFIX = 'sensor.gaggiuino_local_profiler_';
 
-function buildMockStates({ switchState = 'on', readyByTarget = 'unknown' } = {}) {
+function buildMockStates({ switchState = 'on', readyByTarget = 'unknown', isDescaling = false } = {}) {
   const now = Date.now();
   return {
     [PREFIX + 'machine_status']: {
@@ -38,6 +38,12 @@ function buildMockStates({ switchState = 'on', readyByTarget = 'unknown' } = {})
       state: switchState,
       last_changed: new Date(now - 3600 * 1000).toISOString(),
       attributes: {},
+    },
+    // #170: is_descaling lives on the Brewing binary sensor (glp-integration#186),
+    // always present regardless of the brew (is_on) state itself.
+    'binary_sensor.gaggiuino_local_profiler_brewing': {
+      state: 'off',
+      attributes: { is_descaling: isDescaling },
     },
     [PREFIX + 'preheat_ready_by_target_at']:      { state: readyByTarget, attributes: {} },
     [PREFIX + 'preheat_planned_switch_on_at']:    { state: 'unknown', attributes: {} },
@@ -151,6 +157,35 @@ test('a concurrent hass update does not clobber an in-progress ready-by pick', a
     assert.equal(state.pendingTargetAt, true, 'pending target survives the concurrent hass push');
     assert.equal(state.readySetShown, true, 'still shows the set/cancel view, not reverted to the picker');
     assert.equal(state.pickerShown, false);
+    assert.deepEqual(pageErrors, []);
+  } finally {
+    await tearDown(ctx);
+  }
+});
+
+// #170: the Brewing binary sensor's `is_descaling` attribute (glp-integration#186)
+// drives a dedicated banner, same shape as the existing steam-mode banner but
+// its own class/icon/copy.
+test('is_descaling on the Brewing entity shows the descaling banner', async () => {
+  const ctx = await setUpCard(buildMockStates({ isDescaling: true }), '.descaling-banner');
+  const { page, pageErrors } = ctx;
+  try {
+    const bannerText = await page.evaluate(() =>
+      document.querySelector('glp-card').shadowRoot.querySelector('.descaling-banner').textContent.trim());
+    assert.equal(bannerText, 'Entkalkung läuft');
+    assert.deepEqual(pageErrors, []);
+  } finally {
+    await tearDown(ctx);
+  }
+});
+
+test('the descaling banner is absent when is_descaling is false', async () => {
+  const ctx = await setUpCard(buildMockStates({ isDescaling: false }), '.shot-profile');
+  const { page, pageErrors } = ctx;
+  try {
+    const bannerShown = await page.evaluate(() =>
+      !!document.querySelector('glp-card').shadowRoot.querySelector('.descaling-banner'));
+    assert.equal(bannerShown, false);
     assert.deepEqual(pageErrors, []);
   } finally {
     await tearDown(ctx);


### PR DESCRIPTION
## Summary

Adds a `.descaling-banner` to the Live tab, analogous to the existing `.brewing-banner`/`.steam-banner`, so the card visibly shows when the machine is running its descale program. Depends on `glp-integration#186` (merged), which added `is_flushing`/`is_descaling` boolean attributes to the `Brewing` binary sensor's `extra_state_attributes` — always present regardless of the brew (`is_on`) state itself.

- New `descale` icon (droplet + mineral/crystal line), added outside the `GLP-SHARED:icons v1` block (kept byte-identical with `glp-order-card.js`) since that card has no live-brewing view.
- New `.descaling-banner` CSS: same `--accent` color family as `.brewing-banner`/`.maint-pill.due` (this card's own "due maintenance" token), with a slow icon-pulse animation (`descale-pulse`, 1.6s) to visually differentiate it from the static brewing/steam banners.
- Render logic reads `brewingEnt.attributes.is_descaling`, shown when `!brewing` (same guard as the steam banner).
- `descaling_mode` translation key added to all 6 languages (de/en/it/fr/es/nl).
- `GLP_CARD_VERSION` bumped 2.20.5 → 2.21.0 (feature).
- New e2e tests in `test/e2e/smoke.test.mjs`: banner shown with correct text when `is_descaling` is true, absent when false.

## Related issue

Closes #170

## Checklist

- [x] Issue linked above
- [x] `CHANGELOG.md` updated
- [x] `GLP_CARD_VERSION` bumped in `glp-card.js`
- [x] `README.md` updated (if new feature)

## AI assistance disclosure

- [x] **substantial** — AI generated significant portions; human reviewed and revised

Tools / models used: Claude Code (Sonnet 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AERJV7JpwDJLBVYW4Lk7yR