### PR TITLE
chore(release): v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.21.0] – 2026-09-07
 ### Added
 - **Live tab now shows a descaling banner while the machine is running its descale program**, matching the existing brewing/steam banners. Reads the new `is_descaling` attribute on the `Brewing` binary sensor (`glp-integration#186`), always exposed regardless of the brew (`is_on`) state itself, so the banner shows up even when no shot is running. New `.descaling-banner` (own droplet+mineral-crystal icon, `--accent` color family matching this card's existing "due maintenance" tokens, slow icon-pulse animation distinct from the static brewing/steam banners) plus `descaling_mode` translation keys in all 6 languages. `glp-card.js`, `test/e2e/smoke.test.mjs`. Closes #170
 


### PR DESCRIPTION
## Summary

Release commit for v2.21.0: retitles `## [Unreleased]` to `## [2.21.0] – 2026-09-07` in CHANGELOG.md. Tag `v2.21.0` already points at this commit.

## Related issue

N/A — release/chore PR, no issue.

## Checklist

- [x] Issue linked above -- N/A, release PR
- [x] `CHANGELOG.md` updated
- [ ] `DOCS.md` + `DOCS.de.md` updated (if user-facing change) -- N/A, no docs in this repo
- [ ] `README.md` features table updated (if new feature) -- N/A, not a feature
- [x] Version bumped in `glp-card.js` -- already bumped in PR #173

## AI assistance disclosure

- [ ] **none** — no AI tool involved
- [ ] **assisted** — AI autocomplete or review suggestions only; code written by a human
- [x] **substantial** — AI generated significant portions; human reviewed and revised
- [ ] **generated** — code is AI-generated end-to-end; human reviewed and takes responsibility

Tools / models used: Claude Code (Sonnet 5)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AERJV7JpwDJLBVYW4Lk7yR